### PR TITLE
Fix async test failures and deprecation warnings

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,6 +11,8 @@ dependencies = [
     "loguru",
     "typer",
     "pydantic_settings",
+    "pyserial>=3.5",
+    "hidapi>=0.14.0.post4",
 ]
 classifiers = [
   "Development Status :: 4 - Beta",
@@ -31,7 +33,7 @@ Source = "https://github.com/JnyJny/busylight_core"
 
 
 [project.scripts]
-busylight_core = "busylight_core.__main__:cli"
+blc = "busylight_core.__main__:cli"
 
 [build-system]
 requires = ["uv_build>=0.7.19,<0.8"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,6 +44,7 @@ dev = [
     "mypy",
     "poethepoet",
     "pytest",
+    "pytest-asyncio",
     "pytest-cov",
     "ruff",
     "ty",

--- a/src/busylight_core/__init__.py
+++ b/src/busylight_core/__init__.py
@@ -1,8 +1,66 @@
-"""busylight_core.
+"""Support for USB Connected Lights
 
-Busylight Core Implementation for Humans, presumably like you!
+Developers, adding support for a new device will entail:
+
+- Optionally create a new vendor package in the vendors directory.
+- Create a new subclass of busylight_core.light.Light.
+- Implement all the missing abstract methods.
+- Make sure the vendor package imports all the new subclasses.
+- Make sure the vendor package appends the new subclasses to __all__.
+- Import the new subclasses in busylight_core.__init__.
+- Add the new subclasses to busylight_core.__init__.__all__.
+
+Refer to any of the existing vendor packages as an example.
+
+Please note, if the subclasses are not imported here, the
+abc.ABC.__subclasses__ machinery will not find them and your
+new lights will not be recognized.
+
 """
 
 from loguru import logger
+
+from .exceptions import (
+    InvalidHardwareInfo,
+    LightUnavailable,
+    LightUnsupported,
+    NoLightsFound,
+)
+from .hardware import Hardware
+from .light import Light
+from .vendors.agile_innovative import BlinkStick
+from .vendors.compulab import Fit_StatUSB
+from .vendors.embrava import Blynclight, Blynclight_Mini, Blynclight_Plus
+from .vendors.kuando import Busylight_Alpha, Busylight_Omega
+from .vendors.luxafor import Bluetooth, Flag, Mute, Orb
+from .vendors.muteme import MuteMe, MuteMe_Mini
+from .vendors.mutesync import MuteSync
+from .vendors.plantronics import Status_Indicator
+from .vendors.thingm import Blink1
+
+__all__ = [
+    "Blink1",
+    "BlinkStick",
+    "Bluetooth",
+    "Blynclight",
+    "Blynclight_Mini",
+    "Blynclight_Plus",
+    "Busylight_Alpha",
+    "Busylight_Omega",
+    "Fit_StatUSB",
+    "Flag",
+    "Hardware",
+    "InvalidHardwareInfo",
+    "Light",
+    "LightUnavailable",
+    "LightUnsupported",
+    "Mute",
+    "MuteMe",
+    "MuteMe_Mini",
+    "MuteSync",
+    "NoLightsFound",
+    "Orb",
+    "Status_Indicator",
+]
 
 logger.disable("busylight_core")

--- a/src/busylight_core/__main__.py
+++ b/src/busylight_core/__main__.py
@@ -1,4 +1,4 @@
-"""busylight_core CLI implementation.
+"""blc CLI implementation.
 
 Busylight Core Implementation for Humans, presumably like you!
 """

--- a/src/busylight_core/exceptions.py
+++ b/src/busylight_core/exceptions.py
@@ -1,0 +1,23 @@
+""" raised by busylight_core.light.Light and subclasses
+"""
+
+
+class _BaseLightException(Exception):
+    pass
+
+
+class InvalidHardwareInfo(_BaseLightException):
+    """The device dictionary is missing required key/value pairs."""
+
+
+class LightUnavailable(_BaseLightException):
+    """Previously accessible light is now not accessible."""
+
+
+class LightUnsupported(_BaseLightException):
+    """The dictionary passed to an __init__ method of a subclass of Light
+    does not describe a light supported by the subclass."""
+
+
+class NoLightsFound(_BaseLightException):
+    """No lights were discovered by Light or a subclass of Light."""

--- a/src/busylight_core/hardware.py
+++ b/src/busylight_core/hardware.py
@@ -1,0 +1,156 @@
+""" """
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum
+from functools import cached_property
+from typing import Optional
+
+import serial
+from loguru import logger
+from serial.serialutil import SerialException
+from serial.tools import list_ports
+from serial.tools.list_ports_common import ListPortInfo
+
+from . import hid
+
+
+class ConnectionType(int, Enum):
+    ANY: int = -1
+    UNKNOWN: int = 0
+    HID: int = 1
+    SERIAL: int = 2
+    BLUETOOTH: int = 3
+
+
+HardwareHandle = hid.Device | serial.Serial
+
+
+@dataclass
+class Hardware:
+    device_type: ConnectionType
+    path: bytes
+    vendor_id: int
+    product_id: int
+    serial_number: str
+    manufacturer_string: str
+    product_string: Optional[str] = None
+    release_number: Optional[str] = None
+    usage: Optional[int] = None
+    usage_page: Optional[int] = None
+    interface_number: Optional[int] = None
+    bus_type: Optional[int] = None
+    is_acquired: bool = False
+
+    @classmethod
+    def enumerate(cls, by_type: ConnectionType = ConnectionType.ANY) -> list[Hardware]:
+        """List of all connected hardware devices."""
+
+        hardware_info = []
+
+        match by_type:
+            case ConnectionType.ANY:
+                for connection_type in ConnectionType:
+                    if connection_type > 0:
+                        try:
+                            hardware_info.extend(cls.enumerate(connection_type))
+                        except NotImplementedError:
+                            pass
+            case ConnectionType.HID:
+                for device_dict in hid.enumerate():
+                    hardware_info.append(cls.from_hid(device_dict))
+            case ConnectionType.SERIAL:
+                for port_info in list_ports.comports():
+                    hardware_info.append(cls.from_PortInfo(port_info))
+            case _:
+                raise NotImplementedError(f"Device type {by_type} not implemented")
+
+        return hardware_info
+
+    @classmethod
+    def from_PortInfo(cls, port_info: ListPortInfo) -> Hardware:
+        """Create a Hardware object from a serial port info object."""
+        return cls(
+            device_type=ConnectionType.SERIAL,
+            vendor_id=port_info.vid,
+            product_id=port_info.pid,
+            path=port_info.device.encode("utf-8"),
+            serial_number=port_info.serial_number,
+            manufacturer_string=port_info.manufacturer,
+            product_string=port_info.product,
+            bus_type=1,
+        )
+
+    @classmethod
+    def from_hid(cls, device: dict) -> Hardware:
+        """Create a Hardware object from a HID dictionary."""
+        return cls(device_type=ConnectionType.HID, **device)
+
+    @cached_property
+    def device_id(self) -> tuple[int, int]:
+        """A tuple of the vendor and product identifiers."""
+        return (self.vendor_id, self.product_id)
+
+    def __str__(self) -> str:
+        fields = [
+            f"{self.vendor_id:04x}:{self.product_id:04x}",
+            self.manufacturer_string,
+            self.product_string,
+            self.serial_number,
+            self.path.decode("utf-8"),
+        ]
+        return " ".join([field for field in fields if field])
+
+    @cached_property
+    def handle(self) -> HardwareHandle:
+        """An I/O handle for this hardware device."""
+
+        handle: HardwareHandle
+
+        match self.device_type:
+            case ConnectionType.HID:
+                handle = hid.Device()
+            case ConnectionType.SERIAL:
+                handle = serial.Serial(timeout=1)
+                handle.port = self.path.decode("utf-8")
+            case _:
+                raise NotImplementedError(
+                    f"Device type {self.device_type} not implemented"
+                )
+        return handle
+
+    def acquire(self) -> None:
+        """Open the hardware device."""
+
+        if self.is_acquired:
+            logger.debug(f"{self} already acquired")
+            return
+
+        match self.device_type:
+            case ConnectionType.HID:
+                self.handle.open_path(self.path)
+                self.is_acquired = True
+            case ConnectionType.SERIAL:
+                self.handle.open()
+                self.is_acquired = True
+            case _:
+                raise NotImplementedError(
+                    f"{self.device_type.value.title()} hardware not implemented"
+                )
+
+    def release(self) -> None:
+        """Close the hardware device."""
+
+        if not self.is_acquired:
+            logger.debug(f"{self} already released")
+            return
+
+        match self.device_type:
+            case ConnectionType.HID | ConnectionType.SERIAL:
+                self.handle.close()
+                self.is_acquired = False
+            case _:
+                raise NotImplementedError(
+                    f"{self.device_type.value.title()} hardware not implemented"
+                )

--- a/src/busylight_core/hid.py
+++ b/src/busylight_core/hid.py
@@ -1,0 +1,154 @@
+"""USB Human Interface Device (HID) Porcelain.
+
+Why This File Exists.
+
+The 'apmorton/pyhidapi' package and 'trezor/cython-hidapi' packages
+both occupy the namespace hid when installed. Regardless of install
+order, apmorton/pyhidapi wins and overwrites cython-hidapi in the
+directory */lib/python3*/site-packages/hid. The two packages provide
+similar support for performing IO to USB human interface devices with
+small but significant differences. Since I cannot control which
+package is installed first, I've provided a wrapper around the two
+packages that allows either to be used without changing the consumer
+code.
+
+I originally picked the trezor/cython-hidapi package for HID support
+because it does not require the user to install additional non-Python
+software.  The pyhidapi package is a ctypes interface to the hidapi
+shared object which the user must install in an operation separate
+from the `pip install`.
+
+Both cython-hidapi and pyhidapi support a function `enumerate` which
+returns a list of dictionaries, each dictionary describing discovered
+USB devices.
+
+The Device class in this module wallpapers over the differences
+between cython-hidapi::hid.device and pyhidapi::hid.Device, favoring
+the open() semantics of hid.device since it requires fewer changes to
+the consumer in this package.
+
+Hopefully at some point in the future the two projects can come to an
+agreement and remove the namespace collision.
+
+"""
+
+from functools import cached_property
+
+from loguru import logger
+
+import hid
+
+
+def enumerate() -> list[dict]:
+    """Return a list of dictionaries, each describing a USB device."""
+
+    return [dict(**d) for d in hid.enumerate()]
+
+
+class Device:
+    def __init__(self) -> None:
+        try:
+            self._handle = hid.device()
+        except AttributeError:
+            self._handle = None
+        self._is_open = False
+
+    @property
+    def is_open(self) -> bool:
+        """Return True if the device is open."""
+        return self._is_open
+
+    @property
+    def error(self) -> str:
+        """Return the last error message."""
+        try:
+            return self._handle.error()
+        except IOError as error:
+            return str(error)
+
+    def open(
+        self,
+        vendor_id: int,
+        product_id: int,
+        serial_number: str | None = None,
+    ) -> None:
+        """Open the first device matching vendor_id and product_id or
+        serial number.
+
+        If the device is already open, raises IOError.
+        """
+
+        if self.is_open:
+            raise IOError("device already open")
+
+        if self._handle:
+            self._handle.open(vendor_id, product_id, serial_number)
+        else:
+            self._handle = hid.Device(
+                vid=vendor_id,
+                pid=product_id,
+                serial=serial_number,
+            )
+        self._is_open = True
+
+    def open_path(self, path: bytes | str) -> None:
+        """Open the device specified by path.
+
+        If the device is already open, raises IOError.
+        """
+
+        if self.is_open:
+            raise IOError("device already open")
+
+        if isinstance(path, str):
+            path = path.encode("utf-8")
+
+        logger.debug(f"opening device at path {path!r}")
+
+        if self._handle:
+            # hidapi
+            self._handle.open_path(path)
+        else:
+            # pyhidapi
+            self._handle = hid.Device(path=path)
+        self._is_open = True
+
+    def close(self) -> None:
+        """Close this device."""
+        try:
+            self._handle.close()
+            self._is_open = False
+        except AttributeError:
+            raise IOError("device not open") from None
+
+    def read(self, nbytes: int, timeout_ms: int | None = None) -> list[int]:
+        """Read nbytes from the device, returns a list of ints."""
+
+        if not self.is_open:
+            raise IOError("device not open")
+
+        return self._handle.read(nbytes, timeout_ms)
+
+    def write(self, buf: bytes) -> int:
+        """Write bytes in buf to the device."""
+
+        if not self.is_open:
+            raise IOError("device not open")
+
+        return self._handle.write(buf)
+
+    def get_feature_report(self, report: int, nbytes: int) -> list[int]:
+        """Read a nbytes feature report from the device."""
+
+        if not self.is_open:
+            raise IOError("device not open")
+
+        return self._handle.get_feature_report(report, nbytes)
+
+    def send_feature_report(self, buf: bytes) -> int:
+        """Write bytes in buf using device feature report."""
+
+        if not self.is_open:
+            raise IOError("device not open")
+
+        return self._handle.send_feature_report(buf)

--- a/src/busylight_core/light.py
+++ b/src/busylight_core/light.py
@@ -1,0 +1,277 @@
+""" """
+
+from __future__ import annotations
+
+import abc
+import contextlib
+import functools
+import platform
+from functools import cached_property
+from typing import Callable, Generator
+
+from loguru import logger
+
+from .exceptions import LightUnavailable, LightUnsupported, NoLightsFound
+from .hardware import Hardware
+from .mixins import ColorableMixin, TaskableMixin
+
+
+class Light(abc.ABC, ColorableMixin, TaskableMixin):
+
+    @abc.abstractclassmethod
+    @functools.lru_cache(maxsize=1)
+    def supported_device_ids(cls) -> dict[tuple[int, int], str]:
+        """A dictionary of supported device id tuples and names."""
+        raise NotImplementedError
+
+    @classmethod
+    @functools.lru_cache(maxsize=1)
+    def vendor(cls) -> str:
+        """The vendor name in title case."""
+        return cls.__module__.split(".")[-2].title()
+
+    @classmethod
+    @functools.lru_cache(maxsize=1)
+    def unique_device_names(cls) -> list[str]:
+        """Returns a list of unique device names."""
+        return sorted(set(cls.supported_device_ids().values()))
+
+    @classmethod
+    def claims(cls, hardware: Hardware) -> bool:
+        """Returns True if the hardware is claimed by this class."""
+        return hardware.device_id in cls.supported_device_ids()
+
+    @classmethod
+    @functools.lru_cache(maxsize=None)
+    def subclasses(cls) -> list[type[Light]]:
+        """Returns a list of all light subclasses of this class."""
+        subclasses = []
+
+        if cls != Light:
+            subclasses.append(cls)
+
+        for subclass in cls.__subclasses__():
+            subclasses.extend(subclass.subclasses())
+
+        return sorted(subclasses, key=lambda s: s.__module__)
+
+    @classmethod
+    @functools.lru_cache(maxsize=1)
+    def supported_lights(cls) -> dict[str, list[str]]:
+        """A dictionary of supported lights by vendor."""
+        supported_lights: dict[str, list[str]] = {}
+
+        for subclass in cls.subclasses():
+            names = supported_lights.setdefault(subclass.vendor(), [])
+            names.extend(subclass.unique_device_names())
+
+        return supported_lights
+
+    @classmethod
+    def available_lights(cls) -> dict[type[Light], list[Hardware]]:
+        """Returns a dictionary of available hardware by type."""
+
+        available_lights: dict[type[Light], list[Hardware]] = {}
+
+        for hardware in Hardware.enumerate():
+            if cls != Light:
+                if cls.claims(hardware):
+                    logger.debug(f"{cls.__name__} claims {hardware}")
+                    claimed = available_lights.setdefault(cls, [])
+                    claimed.append(hardware)
+            else:
+                for subclass in cls.subclasses():
+                    if subclass.claims(hardware):
+                        logger.debug(f"{subclass.__name__} claims {hardware}")
+                        claimed = available_lights.setdefault(subclass, [])
+                        claimed.append(hardware)
+
+        return available_lights
+
+    @classmethod
+    def all_lights(cls, reset: bool = True, exclusive: bool = True) -> list[Light]:
+        """Returns a list of all lights ready for use."""
+
+        lights: list[Light] = []
+
+        for subclass, devices in cls.available_lights().items():
+            for device in devices:
+                lights.append(subclass(device, reset, exclusive))
+
+        return lights
+
+    @classmethod
+    def first_light(cls, reset: bool = True, exclusive: bool = True) -> Light:
+        """Returns the first unused light ready for use.
+
+        Raises:
+        - NoLightsFound: if no lights are available.
+        """
+
+        for subclass, devices in cls.available_lights().items():
+            for device in devices:
+                try:
+                    return subclass(device, reset, exclusive)
+                except Exception as error:
+                    logger.info(f"Failed to acquire {device}: {error}")
+                    raise
+
+        raise NoLightsFound()
+
+    def __init__(
+        self,
+        hardware: Hardware,
+        reset: bool = False,
+        exclusive: bool = True,
+    ):
+
+        if not self.__class__.claims(hardware):
+            raise LightUnsupported(hardware)
+
+        self.hardware = hardware
+        self._reset = reset
+        self._exclusive = exclusive
+
+        if exclusive:
+            self.hardware.acquire()
+
+        if reset:
+            self.reset()
+
+    def __repr__(self) -> str:
+        return "".join(
+            [
+                f"{self.__class__.__name__}(",
+                f"{self.hardware!r}, reset={self._reset},",
+                f"exclusive={self._exclusive})",
+            ]
+        )
+
+    @cached_property
+    def path(self) -> str:
+        """The path to the hardware device."""
+        return self.hardware.path.decode("utf-8")
+
+    @cached_property
+    def platform(self) -> str:
+        system = platform.system()
+        match system:
+            case "Windows":
+                return f"{system}_{platform.release()}"
+            case _:
+                return system
+
+    @cached_property
+    def _sort_key(self) -> tuple[str, str, str]:
+        return (self.vendor().lower(), self.name.lower(), self.path)
+
+    def __eq__(self, other: object) -> bool:
+        try:
+            return self._sort_key == other._sort_key
+        except AttributeError:
+            raise NotImplemented from None
+
+    def __lt__(self, other: Light) -> bool:
+
+        if not isinstance(other, Light):
+            return NotImplemented
+
+        for self_value, other_value in zip(self._sort_key, other._sort_key):
+            if self_value != other_value:
+                return self_value < other_value
+
+        return False
+
+    def __hash__(self) -> int:
+        try:
+            return self._hash
+        except AttributeError:
+            pass
+        self._hash = hash(self._sort_key)
+        return self._hash
+
+    @cached_property
+    def name(self) -> str:
+        """The marketing name of this light."""
+        return self.supported_device_ids()[self.hardware.device_id]
+
+    @property
+    def hex(self) -> str:
+        """The hexadecimal representation of the light's state."""
+        return bytes(self).hex(":")
+
+    @property
+    def read_strategy(self) -> Callable[[int, int | None], bytes]:
+        """Returns the read method used by this light."""
+        return self.hardware.handle.read
+
+    @property
+    def write_strategy(self) -> Callable[[bytes], None]:
+        """Returns the write method used by this light."""
+        return self.hardware.handle.write
+
+    @contextlib.contextmanager
+    def exclusive_access(self) -> Generator[None, None, None]:
+        """Manage exclusive access to the light.
+
+        If the device is not acquired in exclusive mode, it will be
+        acquired and released automatically.
+        """
+
+        if not self._exclusive:
+            self.hardware.acquire()
+
+        yield
+
+        if not self._exclusive:
+            self.hardware.release()
+
+    def update(self) -> None:
+        """Obtains the current state of the light and writes it to the device."""
+
+        data = bytes(self)
+
+        match self.platform:
+            case "Windows_10":
+                data = bytes([0]) + data
+            case "Darwin" | "Linux" | "Windows_11":
+                pass
+            case _:
+                logger.info(f"Unsupported OS {self.platform}, hoping for the best.")
+
+        with self.exclusive_access():
+
+            logger.debug(f"{self.name} payload {data.hex(':')}")
+
+            try:
+                self.write_strategy(data)
+            except Exception as error:
+                logger.error(f"{self}: {error}")
+                raise LightUnavailable(self) from None
+
+    @contextlib.contextmanager
+    def batch_update(self) -> Generator[None, None, None]:
+        """A context manager for updating the software state of the
+        light and updating the hardware automatically on exit.
+        """
+
+        yield
+        self.update()
+
+    def on(self, color: tuple[int, int, int]) -> None:
+        """Activate the light with the given red, green, blue color tuple."""
+        with self.batch_update():
+            self.color = color
+
+    def off(self) -> None:
+        """Deactivate the light."""
+        self.on((0, 0, 0))
+
+    def reset(self) -> None:
+        """Quiesce the light and associated asynchronous tasks."""
+        self.off()
+        self.cancel_tasks()
+
+    @abc.abstractmethod
+    def __bytes__(self) -> bytes:
+        """The byte representation of the light's state."""

--- a/src/busylight_core/mixins/__init__.py
+++ b/src/busylight_core/mixins/__init__.py
@@ -1,0 +1,10 @@
+"""
+"""
+
+from .colorable import ColorableMixin
+from .taskable import TaskableMixin
+
+__all__ = [
+    "ColorableMixin",
+    "TaskableMixin",
+]

--- a/src/busylight_core/mixins/colorable.py
+++ b/src/busylight_core/mixins/colorable.py
@@ -1,0 +1,46 @@
+"""
+"""
+
+
+class ColorableMixin:
+
+    @property
+    def red(self) -> int:
+        """Red color value."""
+        return getattr(self, "_red", 0)
+
+    @red.setter
+    def red(self, value: int):
+        self._red = value
+
+    @property
+    def green(self) -> int:
+        """Green color value."""
+        return getattr(self, "_green", 0)
+
+    @green.setter
+    def green(self, value: int):
+        self._green = value
+
+    @property
+    def blue(self) -> int:
+        """Blue color value."""
+        return getattr(self, "_blue", 0)
+
+    @blue.setter
+    def blue(self, value: int):
+        self._blue = value
+
+    @property
+    def color(self) -> tuple[int, int, int]:
+        """A tuple of red, green, and blue color values."""
+        return self.red, self.green, self.blue
+
+    @color.setter
+    def color(self, value: tuple[int, int, int]):
+        self.red, self.green, self.blue = value
+
+    @property
+    def is_lit(self) -> bool:
+        """True if any color value is greater than 0."""
+        return any(self.color)

--- a/src/busylight_core/mixins/taskable.py
+++ b/src/busylight_core/mixins/taskable.py
@@ -14,7 +14,10 @@ class TaskableMixin:
     @cached_property
     def event_loop(self):
         """The default event loop."""
-        return asyncio.get_event_loop()
+        try:
+            return asyncio.get_running_loop()
+        except RuntimeError:
+            return asyncio.new_event_loop()
 
     @cached_property
     def tasks(self) -> dict[str, asyncio.Task]:

--- a/src/busylight_core/mixins/taskable.py
+++ b/src/busylight_core/mixins/taskable.py
@@ -1,0 +1,63 @@
+"""Asynchronous task support for animating lights."""
+
+import asyncio
+from functools import cached_property
+from typing import Any, Awaitable, Optional
+
+
+class TaskableMixin:
+    """This mixin class is designed to associate and manage
+    asynchronous tasks. Tasks can be added and cancelled.
+
+    """
+
+    @cached_property
+    def event_loop(self):
+        """The default event loop."""
+        return asyncio.get_event_loop()
+
+    @cached_property
+    def tasks(self) -> dict[str, asyncio.Task]:
+        """Active tasks that are associated with this class."""
+        return {}
+
+    def add_task(self, name: str, coroutine: Awaitable) -> asyncio.Task:
+        """Create a new task using coroutine as the body and stash it in
+        the tasks dictionary property using name as a key.
+
+        :name: str
+        :coroutine: Awaitable
+        :return: asyncio.Task
+        """
+        try:
+            return self.tasks[name]
+        except KeyError:
+            pass
+
+        # >py3.7, create_task takes a `name` parameter
+        self.tasks[name] = self.event_loop.create_task(coroutine(self))
+
+        return self.tasks[name]
+
+    def cancel_task(self, name: str) -> Optional[asyncio.Task]:
+        """Cancels a task associated with name if it exists.  If the
+        task exists the cancelled task is returned, otherwise None.
+
+        :name: str
+        :return: None | asyncio.Task
+        """
+        try:
+            task = self.tasks[name]
+            del self.tasks[name]
+            task.cancel()
+            return task
+        except (KeyError, AttributeError) as error:
+            pass
+
+        return None
+
+    def cancel_tasks(self) -> None:
+        """Cancels all tasks and returns nothing."""
+        for task in self.tasks.values():
+            task.cancel()
+        self.tasks.clear()

--- a/src/busylight_core/vendors/__init__.py
+++ b/src/busylight_core/vendors/__init__.py
@@ -1,0 +1,28 @@
+"""
+"""
+
+from .agile_innovative import BlinkStick
+from .compulab import Fit_StatUSB
+from .embrava import Blynclight, Blynclight_Mini, Blynclight_Plus
+from .kuando import Busylight_Alpha, Busylight_Omega
+from .luxafor import Bluetooth, Flag, Mute, Orb
+from .muteme import MuteMe, MuteMe_Mini
+from .mutesync import MuteSync
+from .plantronics import Status_Indicator
+from .thingm import Blink1
+
+__all__ = [
+    "BlinkStick",
+    "MuteSync",
+    "Blink1",
+    "Busylight_Alpha",
+    "Busylight_Omega",
+    "Bluetooth",
+    "Blynclight",
+    "Blynclight_Mini",
+    "Blynclight_Plus",
+    "Flag",
+    "Mute",
+    "Orb",
+    "Status_Indicator",
+]

--- a/src/busylight_core/vendors/agile_innovative/__init__.py
+++ b/src/busylight_core/vendors/agile_innovative/__init__.py
@@ -1,0 +1,7 @@
+""" Agile Innovative BlinkStick Support
+"""
+
+
+from .blinkstick import BlinkStick
+
+__all__ = ["BlinkStick"]

--- a/src/busylight_core/vendors/agile_innovative/_blinkstick.py
+++ b/src/busylight_core/vendors/agile_innovative/_blinkstick.py
@@ -1,0 +1,62 @@
+""" Agile Innovative BlinkStick implementation details.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum
+
+from loguru import logger
+
+from ...exceptions import LightUnsupported
+from ...hardware import Hardware
+
+
+@dataclass
+class BlinkStickVariant:
+    variant: int
+    name: str
+    nleds: int
+    report: int
+
+    @classmethod
+    def variants(cls) -> dict[str, BlinkStickVariant]:
+        return {
+            "BlinkStick": BlinkStickVariant(1, "BlinkStick", 1, 1),
+            "BlinkStick Pro": BlinkStickVariant(2, "BlinkStick Pro", 192, 4),
+            "BlinkStick Square": BlinkStickVariant(0x200, "BlinkStick Square", 8, 6),
+            "BlinkStick Strip": BlinkStickVariant(0x201, "BlinkStick Strip", 8, 6),
+            "BlinkStick Nano": BlinkStickVariant(0x202, "BlinkStick Nano", 2, 6),
+            "BlinkStick Flex": BlinkStickVariant(0x203, "BlinkStick Flex", 32, 6),
+        }
+
+    @classmethod
+    def from_hardware(cls, hardware: Hardware) -> BlinkStickVariant:
+
+        bs_serial, version = hardware.serial_number.split("-")
+        bs_serial = bs_serial[2:]
+        major, minor = version.split(".")
+
+        variants = cls.variants()
+
+        match major:
+            case "1":
+                return variants["BlinkStick"]
+            case "2":
+                return variants["BlinkStick Pro"]
+            case "3":
+                match hardware.release_number:
+                    case 0x200:
+                        return variants["BlinkStick Square"]
+                    case 0x201:
+                        return variants["BlinkStick Strip"]
+                    case 0x202:
+                        return variants["BlinkStick Nano"]
+                    case 0x203:
+                        return variants["BlinkStick Flex"]
+                    case _:
+                        logger.error(f"unknown release {hardware.release}")
+            case _:
+                logger.error(f"unknown major {major}")
+
+        raise LightUnsupported(Hardware)

--- a/src/busylight_core/vendors/agile_innovative/blinkstick.py
+++ b/src/busylight_core/vendors/agile_innovative/blinkstick.py
@@ -1,0 +1,56 @@
+"""Agile Innovative BlinkStick"""
+
+from functools import cached_property
+
+from loguru import logger
+
+from ...light import Light
+from ._blinkstick import BlinkStickVariant
+
+
+class BlinkStick(Light):
+    @staticmethod
+    def supported_device_ids() -> dict[tuple[int, int], str]:
+        return {
+            (0x20A0, 0x41E5): "BlinkStick",
+        }
+
+    @staticmethod
+    def vendor() -> str:
+        return "Agile Innovative"
+
+    @property
+    def channel(self) -> int:
+        return getattr(self, "_channel", 0)
+
+    @channel.setter
+    def channel(self, value: int) -> None:
+        self._channel = value
+
+    @property
+    def index(self) -> int:
+        return getattr(self, "_index", 0)
+
+    @index.setter
+    def index(self, value: int) -> None:
+        self._index = value
+
+    @cached_property
+    def variant(self) -> BlinkStickVariant:
+        return BlinkStickVariant.from_hardware(self.hardware)
+
+
+    @property
+    def name(self) -> str:
+        return self.variant.name
+
+    def __bytes__(self) -> bytes:
+
+        match self.variant.report:
+            case 1:
+                buf = [self.variant.report, self.green, self.red, self.blue]
+            case _:
+                buf = [self.variant.report, self.channel]
+                buf.extend([self.green, self.red, self.blue] * self.variant.nleds)
+
+        return bytes(buf)

--- a/src/busylight_core/vendors/busytag/__init__.py
+++ b/src/busylight_core/vendors/busytag/__init__.py
@@ -1,0 +1,5 @@
+""" """
+
+from .busytag import BusyTag
+
+__all__ = ["BusyTag"]

--- a/src/busylight_core/vendors/busytag/busytag.py
+++ b/src/busylight_core/vendors/busytag/busytag.py
@@ -1,0 +1,24 @@
+"""BusyTag Light Support"""
+
+from ...light import Light
+
+# https://luxafor.helpscoutdocs.com/article/47-busy-tag-usb-cdc-command-reference-guide
+
+
+class BusyTag(Light):
+
+    @staticmethod
+    def supported_device_ids() -> dict[tuple[int, int], str]:
+        return {
+            (0x303A, 0x81DF): "Busy Tag",
+        }
+
+    @staticmethod
+    def vendor() -> str:
+        return "Busy Tag"
+
+    def __bytes__(self) -> bytes:
+
+        cmd = f"AT+SC=127,{self.red:02x}{self.green:02x}{self.blue:02x}"
+
+        return buf.encode()

--- a/src/busylight_core/vendors/compulab/__init__.py
+++ b/src/busylight_core/vendors/compulab/__init__.py
@@ -1,0 +1,6 @@
+"""CompuLab Fit-statUSB Support
+"""
+
+from .fit_statusb import Fit_StatUSB
+
+__all__ = ["Fit_StatUSB"]

--- a/src/busylight_core/vendors/compulab/fit_statusb.py
+++ b/src/busylight_core/vendors/compulab/fit_statusb.py
@@ -1,0 +1,24 @@
+"""
+"""
+
+from loguru import logger
+
+from ...light import Light
+
+
+class Fit_StatUSB(Light):
+    @staticmethod
+    def supported_device_ids() -> dict[tuple[int, int], str]:
+        return {
+            (0x2047, 0x03DF): "fit-statUSB",
+        }
+
+    @staticmethod
+    def vendor() -> str:
+        return "CompuLab"
+
+    def __bytes__(self) -> bytes:
+
+        buf = f"B#{self.red:02x}{self.green:02x}{self.blue:02x}\n"
+
+        return buf.encode()

--- a/src/busylight_core/vendors/embrava/__init__.py
+++ b/src/busylight_core/vendors/embrava/__init__.py
@@ -1,0 +1,12 @@
+"""Embrava Blynclight Support
+"""
+
+from .blynclight import Blynclight
+from .blynclight_mini import Blynclight_Mini
+from .blynclight_plus import Blynclight_Plus
+
+__all__ = [
+    "Blynclight",
+    "Blynclight_Mini",
+    "Blynclight_Plus",
+]

--- a/src/busylight_core/vendors/embrava/_blynclight.py
+++ b/src/busylight_core/vendors/embrava/_blynclight.py
@@ -1,0 +1,102 @@
+""" Embrava Blynclight Implementation Details
+"""
+
+import struct
+
+from ...word import BitField, Word
+
+
+class OffBit(BitField):
+    """1 bit field to turn light off, clear to turn light on."""
+
+    def __init__(self) -> None:
+        super().__init__(17, 1)
+
+
+class DimBit(BitField):
+    """1 bit field to dim light, clear to brighten light."""
+
+    def __init__(self) -> None:
+        super().__init__(18, 1)
+
+
+class FlashBit(BitField):
+    """1 bit field to flash light, clear to stop flashing."""
+
+    def __init__(self) -> None:
+        super().__init__(19, 1)
+
+
+class SpeedField(BitField):
+    """3 bit field to set flash speed: 1=slow, 2=medium, 4=fast."""
+
+    def __init__(self) -> None:
+        super().__init__(20, 3)
+
+
+class RepeatBit(BitField):
+    """1 bit field to repeat sound, clear to play sound once."""
+
+    def __init__(self) -> None:
+        super().__init__(13, 1)
+
+
+class PlayBit(BitField):
+    """1 bit field to play sound, clear to stop sound."""
+
+    def __init__(self) -> None:
+        super().__init__(12, 1)
+
+
+class MusicField(BitField):
+    """4 bit field to select music to play, ranges from 0 to 15."""
+
+    def __init__(self) -> None:
+        super().__init__(8, 4)
+
+
+class VolumeField(BitField):
+    """4 bit field to set volume level, ranges from 0 to 15."""
+
+    def __init__(self) -> None:
+        super().__init__(0, 4)
+
+
+class MuteBit(BitField):
+    """1 bit field to mute sound, clear to enable sound."""
+
+    def __init__(self) -> None:
+        super().__init__(4, 1)
+
+
+class State(Word):
+
+    def __init__(self) -> None:
+        super().__init__(0, 24)
+
+    def __repr__(self) -> str:
+        return f"{self.__class__.__name__}(0x{self!s})"
+
+    def __str__(self) -> str:
+        fields = [
+            f"off:    {self.off}",
+            f"dim:    {self.dim}",
+            f"flash:  {self.flash}",
+            f"speed:  {self.speed}",
+            f"repeat: {self.repeat}",
+            f"play:   {self.play}",
+            f"music:  {self.music}",
+            f"volume: {self.volume}",
+            f"mute:   {self.mute}",
+        ]
+        return "\n".join(fields)
+
+    off = OffBit()
+    dim = DimBit()
+    flash = FlashBit()
+    speed = SpeedField()
+    repeat = RepeatBit()
+    play = PlayBit()
+    music = MusicField()
+    volume = VolumeField()
+    mute = MuteBit()

--- a/src/busylight_core/vendors/embrava/blynclight.py
+++ b/src/busylight_core/vendors/embrava/blynclight.py
@@ -1,0 +1,120 @@
+""" """
+
+import struct
+from enum import Enum
+from functools import cached_property
+
+from loguru import logger
+
+from ...light import Light
+from ._blynclight import State
+
+
+class FlashSpeed(int, Enum):
+    slow: int = 1
+    medium: int = 2
+    fast: int = 4
+
+
+class Blynclight(Light):
+
+    @staticmethod
+    def supported_device_ids() -> dict[tuple[int, int], str]:
+        return {
+            (0x2C0D, 0x0001): "Blynclight",
+            (0x2C0D, 0x000C): "Blynclight",
+            (0x0E53, 0x2516): "Blynclight",
+        }
+
+    @cached_property
+    def state(self) -> State:
+        return State()
+
+    @cached_property
+    def struct(self) -> struct.Struct:
+        return struct.Struct("!xBBBBBBH")
+
+    def __bytes__(self) -> bytes:
+
+        self.state.off = not self.is_lit
+
+        if self.state.flash and self.state.off:
+            self.state.flash = False
+
+        if self.state.dim and self.state.off:
+            self.state.dim = False
+
+        return self.struct.pack(
+            self.red,
+            self.blue,
+            self.green,
+            *bytes(self.state),
+            0xFF22,
+        )
+
+    def dim(self) -> None:
+
+        with self.batch_update():
+            self.state.dim = True
+
+    def bright(self) -> None:
+
+        with self.batch_update():
+            self.state.dim = False
+
+    def play_sound(
+        self,
+        music: int = 0,
+        volume: int = 1,
+        repeat: bool = False,
+    ) -> None:
+
+        with self.batch_update():
+            self.state.repeat = repeat
+            self.state.play = True
+            self.state.music = music
+            self.state.mute = False
+
+    def stop_sound(self) -> None:
+
+        with self.batch_update():
+            self.state.play = False
+
+    def mute(self) -> None:
+
+        with self.batch_update():
+            self.state.mute = True
+
+    def unmute(self) -> None:
+
+        with self.batch_update():
+            self.state.mute = False
+
+    def flash(self, color: tuple[int, int, int], speed: FlashSpeed = None) -> None:
+
+        speed = speed or FlashSpeed.slow
+
+        with self.batch_update():
+            self.color = color
+            self.state.flash = True
+            self.state.speed = speed.value
+
+    def stop_flashing(self) -> None:
+
+        with self.batch_update():
+            self.state.flash = False
+
+    def reset(self) -> None:
+
+        with self.batch_update():
+            self.state.off = True
+            self.state.dim = False
+            self.state.flash = False
+            self.state.speed = FlashSpeed.slow.value
+            self.state.play = False
+            self.state.mute = False
+            self.state.repeat = False
+            self.state.music = 0
+            self.state.volume = 0
+
+        super().reset()

--- a/src/busylight_core/vendors/embrava/blynclight_mini.py
+++ b/src/busylight_core/vendors/embrava/blynclight_mini.py
@@ -1,0 +1,13 @@
+"""
+"""
+
+from .blynclight import Blynclight
+
+
+class Blynclight_Mini(Blynclight):
+    @staticmethod
+    def supported_device_ids() -> dict[tuple[int, int], str]:
+        return {
+            (0x2C0D, 0x000A): "Blynclight Mini",
+            (0x0E53, 0x2517): "Blynclight Mini",
+        }

--- a/src/busylight_core/vendors/embrava/blynclight_plus.py
+++ b/src/busylight_core/vendors/embrava/blynclight_plus.py
@@ -1,0 +1,13 @@
+"""
+"""
+
+from .blynclight import Blynclight
+
+
+class Blynclight_Plus(Blynclight):
+    @staticmethod
+    def supported_device_ids() -> dict[tuple[int, int], str]:
+        return {
+            (0x2C0D, 0x0002): "Blynclight Plus",
+            (0x2C0D, 0x0010): "Blynclight Plus",
+        }

--- a/src/busylight_core/vendors/kuando/__init__.py
+++ b/src/busylight_core/vendors/kuando/__init__.py
@@ -1,0 +1,10 @@
+""" Kuando Busylight Support
+"""
+
+from .busylight_alpha import Busylight_Alpha
+from .busylight_omega import Busylight_Omega
+
+__all__ = [
+    "Busylight_Alpha",
+    "Busylight_Omega",
+]

--- a/src/busylight_core/vendors/kuando/_busylight.py
+++ b/src/busylight_core/vendors/kuando/_busylight.py
@@ -1,0 +1,244 @@
+"""
+"""
+
+import struct
+from enum import Enum
+
+from ...word import BitField, ReadOnlyBitField, Word
+
+
+class Ring(int, Enum):
+    Off: int = 0
+    OpenOffice: int = 136
+    Quiet: int = 144
+    Funky: int = 152
+    FairyTale: int = 160
+    KuandoTrain: int = 168
+    TelephoneNordic: int = 176
+    TelephoneOriginal: int = 184
+    TelephonePickMeUp: int = 192
+    Buzz: int = 216
+
+
+class OpCode(int, Enum):
+    Jump: int = 0x1
+    Reset: int = 0x2
+    Boot: int = 0x4
+    KeepAlive: int = 0x8
+
+
+class OpCodeField(BitField):
+    """4-bit opcode"""
+
+    def __init__(self) -> None:
+        super().__init__(60, 4)
+
+
+class OperandField(BitField):
+    """4-bit operand"""
+
+    def __init__(self) -> None:
+        super().__init__(56, 4)
+
+
+class BodyField(BitField):
+    """56-bit body"""
+
+    def __init__(self) -> None:
+        super().__init__(0, 56)
+
+
+class RepeatField(BitField):
+    """8-bit repeat"""
+
+    def __init__(self) -> None:
+        super().__init__(48, 8)
+
+
+class ColorField(BitField):
+    def __set__(self, instance, value):
+        super().__set__(instance, int((value / 255) * 100))
+
+    def __get__(self, instance, owner):
+        return int((super().__get__(instance, owner) / 100 * 0xFF))
+
+
+class RedField(ColorField):
+    """8-bit red"""
+
+    def __init__(self) -> None:
+        super().__init__(40, 8)
+
+
+class GreenField(ColorField):
+    """8-bit green"""
+
+    def __init__(self) -> None:
+        super().__init__(32, 8)
+
+
+class BlueField(ColorField):
+    """8-bit blue"""
+
+    def __init__(self) -> None:
+        super().__init__(24, 8)
+
+
+class DutyCycleOnField(BitField):
+    """8-bit duty cycle on"""
+
+    def __init__(self) -> None:
+        super().__init__(16, 8)
+
+
+class DutyCycleOffField(BitField):
+    """8-bit duty cycle off"""
+
+    def __init__(self) -> None:
+        super().__init__(8, 8)
+
+
+class UpdateBit(BitField):
+    """1-bit update"""
+
+    def __init__(self) -> None:
+        super().__init__(7, 1)
+
+
+class RingtoneField(BitField):
+    """4-bit ringtone"""
+
+    def __init__(self) -> None:
+        super().__init__(3, 4)
+
+
+class VolumeField(BitField):
+    """3-bit volume"""
+
+    def __init__(self) -> None:
+        super().__init__(0, 3)
+
+
+class Step(Word):
+    def __init__(self) -> None:
+        super().__init__(0, 64)
+
+    def keep_alive(self, timeout: int) -> None:
+        """Configure the step as a KeepAlive with timeout in seconds."""
+        self.opcode = OpCode.KeepAlive
+        self.operand = timeout & 0xF
+        self.body = 0
+
+    def boot(self) -> None:
+        """Configure the step as a Boot instruction."""
+        self.opcode = OpCode.Boot
+        self.operand = 0
+        self.body = 0
+
+    def reset(self) -> None:
+        """Configure the step as a Reset instruction."""
+        self.opcode = OpCode.Reset
+        self.operand = 0
+        self.body = 0
+
+    def jump(
+        self,
+        color: tuple[int, int, int],
+        target: int = 0,
+        repeat: int = 0,
+        on_time: int = 0,
+        off_time: int = 0,
+        update: int = 0,
+        ringtone: Ring = Ring.Off,
+        volume: int = 0,
+    ) -> None:
+        """Configure the step as a Jump instruction."""
+        self.opcode = OpCode.Jump
+        self.operand = target & 0xF
+        self.repeat = repeat & 0xFF
+        self.color = color
+        self.duty_cycle_on = on_time & 0xFF
+        self.duty_cycle_off = off_time & 0xFF
+        self.update = update & 0x1
+        self.ringtone = ringtone & 0xF
+        self.volume = volume & 0x3
+
+    @property
+    def color(self) -> tuple[int, int, int]:
+        return (self.red, self.green, self.blue)
+
+    @color.setter
+    def color(self, color: tuple[int, int, int]) -> None:
+        self.red, self.green, self.blue = color
+
+    opcode = OpCodeField()
+    operand = OperandField()
+    body = BodyField()
+    repeat = RepeatField()
+    red = RedField()
+    green = GreenField()
+    blue = BlueField()
+    duty_cycle_on = DutyCycleOnField()
+    duty_cycle_off = DutyCycleOffField()
+    update = UpdateBit()
+    ringtone = RingtoneField()
+    volume = VolumeField()
+
+
+class SensitivityField(BitField):
+    """8-bit sensitivity"""
+
+    def __init__(self) -> None:
+        super().__init__(56, 8)
+
+
+class TimeoutField(BitField):
+    """8-bit timeout"""
+
+    def __init__(self) -> None:
+        super().__init__(48, 8)
+
+
+class TriggerField(BitField):
+    """8-bit trigger"""
+
+    def __init__(self) -> None:
+        super().__init__(40, 8)
+
+
+class ChecksumField(BitField):
+    """16-bit checksum"""
+
+    def __init__(self) -> None:
+        super().__init__(0, 16)
+
+
+class Footer(Step):
+    def __init__(self) -> None:
+        super().__init__()
+        self.checksum = 0
+        self.pad = 0xFFF
+
+    sensitivity = SensitivityField()
+    timeout = TimeoutField()
+    trigger = TriggerField()
+    pad = BitField(16, 24)
+    checksum = ChecksumField()
+
+
+class State:
+    def __init__(self):
+        self.steps = [Step() for _ in range(7)]
+        self.footer = Footer()
+        self.struct = struct.Struct("!8Q")
+
+    def __bytes__(self):
+
+        self.footer.checksum = sum(bytes(self.footer)[:-2])
+        for step in self.steps:
+            self.footer.checksum += sum(bytes(step))
+
+        return self.struct.pack(
+            *[step.value for step in self.steps],
+            self.footer.value,
+        )

--- a/src/busylight_core/vendors/kuando/busylight_alpha.py
+++ b/src/busylight_core/vendors/kuando/busylight_alpha.py
@@ -1,0 +1,60 @@
+"""Busylight Alpha Support"""
+
+import asyncio
+from functools import cached_property
+
+from loguru import logger
+
+from ...hardware import Hardware
+from ...light import Light
+from ._busylight import State
+
+
+class Busylight_Alpha(Light):
+    @staticmethod
+    def supported_device_ids() -> dict[tuple[int, int], str]:
+        return {
+            (0x04D8, 0xF848): "Busylight Alpha",
+            (0x27BB, 0x3BCA): "Busylight Alpha",
+            (0x27BB, 0x3BCB): "Busylight Alpha",
+            (0x27BB, 0x3BCE): "Busylight Alpha",
+        }
+
+    @cached_property
+    def state(self) -> State:
+        return State()
+
+    def __bytes__(self) -> bytes:
+        return bytes(self.state)
+
+    def on(self, color: tuple[int, int, int]) -> None:
+        self.color = color
+        with self.batch_update():
+            self.state.steps[0].jump(color)
+
+        self.add_task("keepalive", _keepalive)
+
+    def off(self) -> None:
+        self.color = (0, 0, 0)
+        with self.batch_update():
+            self.state.steps[0].jump((0, 0, 0))
+        self.cancel_task("keepalive")
+
+
+async def _keepalive(light: Busylight_Alpha, interval: int = 15) -> None:
+    """Send a keep alive packet to a Busylight.
+
+    The hardware will be configured for a keep alive interval of
+    `interval` seconds, and an asyncio sleep for half that time will
+    be used to schedule the next keep alive packet update.
+    """
+
+    if interval not in range(0, 16):
+        raise ValueError("Keepalive interval must be between 0 and 15 seconds.")
+
+    sleep_interval = round(interval / 2)
+
+    while True:
+        with light.batch_update():
+            light.state.steps[0].keepalive(interval)
+        await asyncio.sleep(sleep_interval)

--- a/src/busylight_core/vendors/kuando/busylight_omega.py
+++ b/src/busylight_core/vendors/kuando/busylight_omega.py
@@ -1,0 +1,13 @@
+""" Busylight Omega Support
+"""
+
+from .busylight_alpha import Busylight_Alpha
+
+
+class Busylight_Omega(Busylight_Alpha):
+    @staticmethod
+    def supported_device_ids() -> dict[tuple[int, int], str]:
+        return {
+            (0x27BB, 0x3BCD): "Busylight Omega",
+            (0x27BB, 0x3BCF): "Busylight Omega",
+        }

--- a/src/busylight_core/vendors/luxafor/__init__.py
+++ b/src/busylight_core/vendors/luxafor/__init__.py
@@ -1,0 +1,14 @@
+""" Luxafor Flag, Mute and Orb Support
+"""
+
+from .bluetooth import Bluetooth
+from .flag import Flag
+from .mute import Mute
+from .orb import Orb
+
+__all__ = [
+    "Bluetooth",
+    "Flag",
+    "Mute",
+    "Orb",
+]

--- a/src/busylight_core/vendors/luxafor/_flag.py
+++ b/src/busylight_core/vendors/luxafor/_flag.py
@@ -1,0 +1,71 @@
+"""
+"""
+
+from enum import Enum
+
+
+class Command(int, Enum):
+    Color: int = 1
+    Fade: int = 2
+    Strobe: int = 3
+    Wave: int = 4
+    Pattern: int = 6
+
+
+class LEDS(int, Enum):
+    All: int = 0xFF
+    Back: int = 0x41
+    Front: int = 0x42
+    LED1: int = 0x1
+    LED2: int = 0x2
+    LED3: int = 0x3
+    LED4: int = 0x4
+    LED5: int = 0x5
+    LED6: int = 0x6
+
+
+class Pattern(int, Enum):
+    Off: int = 0
+    TrafficLight: int = 1
+    Random1: int = 2
+    Random2: int = 3
+    Random3: int = 4
+    Police: int = 5
+    Random4: int = 6
+    Random5: int = 7
+    Rainbow: int = 8
+
+
+class Wave(int, Enum):
+    Off: int = 0
+    Short: int = 1
+    Long: int = 2
+    ShortOverLapping: int = 3
+    LongOverlapping: int = 4
+    WAVE5: int = 5
+
+
+class State:
+    def __init__(self) -> None:
+        self.command = Command.Color
+        self.leds = LEDS.All
+        self.fade = 0
+        self.repeat = 0
+        self.pattern = Pattern.Off
+        self.wave = Wave.Off
+        self.color = (0, 0, 0)
+
+    def __bytes__(self) -> bytes:
+
+        match self.command:
+            case Command.Color:
+                return bytes([self.command, self.leds, *self.color])
+            case Command.Fade:
+                return bytes(
+                    [self.command, self.leds, *self.color, self.fade, self.repeat]
+                )
+            case _:
+                pass
+
+        logger.debug(f"Unsupported command: {self.command}")
+        raise ValueError(f"Unsupported command: {self.command}")

--- a/src/busylight_core/vendors/luxafor/bluetooth.py
+++ b/src/busylight_core/vendors/luxafor/bluetooth.py
@@ -1,0 +1,12 @@
+""" Luxafor Bluetooth
+"""
+
+from .flag import Flag
+
+
+class Bluetooth(Flag):
+    @staticmethod
+    def supported_device_ids() -> dict[tuple[int, int], str]:
+        return {
+            (0x4D8, 0xF372): "BT",
+        }

--- a/src/busylight_core/vendors/luxafor/flag.py
+++ b/src/busylight_core/vendors/luxafor/flag.py
@@ -1,0 +1,43 @@
+"""Luxafor Flag"""
+
+from functools import cached_property
+
+from loguru import logger
+
+from ...hardware import Hardware
+from ...light import Light
+from ._flag import LEDS, Command, Pattern, State, Wave
+
+
+class Flag(Light):
+    @staticmethod
+    def supported_device_ids() -> dict[tuple[int, int], str]:
+        return {
+            (0x4D8, 0xF372): "Flag",
+        }
+
+    @classmethod
+    def claims(cls, hardware: Hardware) -> bool:
+
+        if not super().claims(hardware):
+            return False
+
+        try:
+            product = hardware.product_string.split()[-1].casefold()
+        except (KeyError, IndexError) as error:
+            logger.debug(f"problem {error} processing {hardware}")
+            return False
+
+        return product in [
+            value.casefold() for value in cls.supported_device_ids().values()
+        ]
+
+    @cached_property
+    def state(self) -> State:
+        return State()
+
+    def __bytes__(self) -> bytes:
+
+        self.state.color = self.color
+
+        return bytes(self.state)

--- a/src/busylight_core/vendors/luxafor/mute.py
+++ b/src/busylight_core/vendors/luxafor/mute.py
@@ -1,0 +1,34 @@
+""" Luxafor Mute
+"""
+
+from loguru import logger
+
+from .flag import Flag
+
+
+class Mute(Flag):
+    @staticmethod
+    def supported_device_ids() -> dict[tuple[int, int], str]:
+        return {
+            (0x4D8, 0xF372): "Mute",
+        }
+
+    @property
+    def is_button(self) -> bool:
+        return True
+
+    @property
+    def button_on(self) -> bool:
+
+        results = self.read_strategy(8, 200)
+
+        try:
+            if results[0] == 66:
+                self._button = False  # ???
+
+            if results[0] == 131:
+                return bool(results[1])
+        except IndexError:
+            pass
+
+        return False

--- a/src/busylight_core/vendors/luxafor/orb.py
+++ b/src/busylight_core/vendors/luxafor/orb.py
@@ -1,0 +1,12 @@
+""" Luxafor Orb
+"""
+
+from .flag import Flag
+
+
+class Orb(Flag):
+    @staticmethod
+    def supported_device_ids() -> dict[tuple[int, int], str]:
+        return {
+            (0x4D8, 0xF372): "Orb",
+        }

--- a/src/busylight_core/vendors/muteme/__init__.py
+++ b/src/busylight_core/vendors/muteme/__init__.py
@@ -1,0 +1,11 @@
+""" MuteMe Device Support
+"""
+
+
+from .muteme import MuteMe
+from .muteme_mini import MuteMe_Mini
+
+__all__ = [
+    "MuteMe",
+    "MuteMe_Mini",
+]

--- a/src/busylight_core/vendors/muteme/_muteme.py
+++ b/src/busylight_core/vendors/muteme/_muteme.py
@@ -1,0 +1,75 @@
+""" MuteMe Implementation Details
+"""
+
+from loguru import logger
+
+from ...word import BitField, Word
+
+
+class OneBitField(BitField):
+    def __get__(self, instance, owner) -> int:
+        return 0xFF if super().__get__(instance, owner) else 0
+
+    def __set__(self, instance, value) -> None:
+        super().__set__(instance, value & 1)
+
+
+class RedBit(OneBitField):
+    """1-bit red color field"""
+
+    def __init__(self) -> None:
+        super().__init__(0, 1)
+
+
+class GreenBit(OneBitField):
+    """1-bit green color field"""
+
+    def __init__(self) -> None:
+        super().__init__(1, 1)
+
+
+class BlueBit(OneBitField):
+    """1-bit blue color field"""
+
+    def __init__(self) -> None:
+        super().__init__(2, 1)
+
+
+class DimBit(OneBitField):
+    """1-bit dim field"""
+
+    def __init__(self) -> None:
+        super().__init__(4, 1)
+
+
+class BlinkBit(OneBitField):
+    """1-bit blink field"""
+
+    def __init__(self) -> None:
+        super().__init__(5, 1)
+
+
+class SleepBit(OneBitField):
+    """1-bit sleep field"""
+
+    def __init__(self) -> None:
+        super().__init__(6, 1)
+
+
+class State(Word):
+    """MuteMe state word"""
+
+    red = RedBit()
+    green = GreenBit()
+    blue = BlueBit()
+    dim = DimBit()
+    blink = BlinkBit()
+    sleep = SleepBit()
+
+    @property
+    def color(self) -> tuple[int, int, int]:
+        return self.red, self.green, self.blue
+
+    @color.setter
+    def color(self, values: tuple[int, int, int]):
+        self.red, self.green, self.blue = values

--- a/src/busylight_core/vendors/muteme/muteme.py
+++ b/src/busylight_core/vendors/muteme/muteme.py
@@ -1,0 +1,53 @@
+"""MuteMe Button & Light"""
+
+import struct
+from functools import cached_property
+
+from loguru import logger
+
+from ...light import Light
+from ._muteme import State
+
+
+class MuteMe(Light):
+    @staticmethod
+    def supported_device_ids() -> dict[tuple[int, int], str]:
+        return {
+            (0x16C0, 0x27DB): "MuteMe Original",
+            (0x20A0, 0x42DA): "MuteMe Original",
+        }
+
+    @staticmethod
+    def vendor() -> str:
+        return "MuteMe"
+
+    @cached_property
+    def state(self) -> State():
+        return State()
+
+    @cached_property
+    def struct(self) -> struct.Struct:
+        return struct.Struct("!xB")
+
+    def __bytes__(self) -> bytes:
+        self.state.color = self.color
+        return self.struct.pack(self.state.value)
+
+    @property
+    def is_pluggedin(self) -> bool:
+
+        # EJO No reason for eight, just a power of two.
+        try:
+            nbytes = self.hardware.send_feature_report([0] * 8)
+            return nbytes == 8
+        except ValueError:
+            pass
+        return False
+
+    @property
+    def is_button(self) -> bool:
+        return True
+
+    @property
+    def button_on(self) -> bool:
+        raise NotImplementedError()

--- a/src/busylight_core/vendors/muteme/muteme_mini.py
+++ b/src/busylight_core/vendors/muteme/muteme_mini.py
@@ -1,0 +1,12 @@
+""" MuteMe Mini Support
+"""
+
+from .muteme import MuteMe
+
+
+class MuteMe_Mini(MuteMe):
+    @staticmethod
+    def supported_device_ids() -> dict[tuple[int, int], str]:
+        return {
+            (0x20A0, 0x42DB): "MuteMe Mini",
+        }

--- a/src/busylight_core/vendors/mutesync/__init__.py
+++ b/src/busylight_core/vendors/mutesync/__init__.py
@@ -1,0 +1,6 @@
+""" MuteSync Device Support
+"""
+
+from .mutesync import MuteSync
+
+__all__ = ["MuteSync"]

--- a/src/busylight_core/vendors/mutesync/mutesync.py
+++ b/src/busylight_core/vendors/mutesync/mutesync.py
@@ -1,0 +1,57 @@
+"""
+"""
+
+from loguru import logger
+
+from ...hardware import Hardware
+from ...light import Light
+
+
+class MuteSync(Light):
+    @staticmethod
+    def supported_device_ids() -> dict[tuple[int, int], str]:
+        return {
+            (0x10C4, 0xEA60): "MuteSync Button",
+        }
+
+    @staticmethod
+    def vendor() -> str:
+        return "MuteSync"
+
+    @classmethod
+    def claims(cls, hardware: Hardware) -> bool:
+        """Returns True if the hardware describes a MuteSync Button."""
+
+        # Addresses issue #356 where MuteSync claims another hardware with
+        # a SiliconLabs CP2102 USB to Serial controller that is not a MuteSync
+        # hardware.
+
+        claim = super().claims(hardware)
+
+        vendor = cls.vendor().lower()
+
+        try:
+            manufacturer = vendor in hardware.manufacturer_string.lower()
+        except AttributeError:
+            manufacturer = False
+
+        try:
+            product = vendor in hardware.product_string.lower()
+        except AttributeError:
+            product = False
+
+        return claim and (product or manufacturer)
+
+    def __bytes__(self) -> bytes:
+
+        buf = [65] + [*self.color] * 4
+
+        return bytes(buf)
+
+    @property
+    def is_button(self) -> bool:
+        return True
+
+    @property
+    def button_on(self) -> bool:
+        return False

--- a/src/busylight_core/vendors/plantronics/__init__.py
+++ b/src/busylight_core/vendors/plantronics/__init__.py
@@ -1,0 +1,6 @@
+"""
+"""
+
+from .status_indicator import Status_Indicator
+
+__all__ = ["Status_Indicator"]

--- a/src/busylight_core/vendors/plantronics/status_indicator.py
+++ b/src/busylight_core/vendors/plantronics/status_indicator.py
@@ -1,0 +1,13 @@
+"""Plantronics Status Indicator
+"""
+
+from ..embrava.blynclight import Blynclight
+
+
+class Status_Indicator(Blynclight):
+
+    @staticmethod
+    def supported_device_ids() -> dict[tuple[int, int], str]:
+        return {
+            (0x047F, 0xD005): "Status Indicator",
+        }

--- a/src/busylight_core/vendors/thingm/__init__.py
+++ b/src/busylight_core/vendors/thingm/__init__.py
@@ -1,0 +1,6 @@
+""" ThingM Blink(1) Support
+"""
+
+from .blink1 import Blink1
+
+__all__ = ["Blink1"]

--- a/src/busylight_core/vendors/thingm/_blink1.py
+++ b/src/busylight_core/vendors/thingm/_blink1.py
@@ -1,0 +1,198 @@
+"""
+"""
+
+from enum import Enum
+
+from ...word import BitField, Word
+
+
+class Action(int, Enum):
+    FadeColor = ord("c")
+    SetColor = ord("n")
+    ReadColor = ord("r")
+    ServerTickle = ord("D")
+    PlayLoop = ord("p")
+    PlayStateRead = ord("S")
+    SetColorPattern = ord("P")
+    SaveColorPatterns = ord("W")
+    ReadColorPattern = ord("R")
+    SetLEDn = ord("l")
+    ReadEEPROM = ord("e")
+    WriteEEPROM = ord("E")
+    GetVersion = ord("v")
+    TestCommand = ord("!")
+    WriteNote = ord("F")
+    ReadNote = ord("f")
+    Bootloader = ord("G")
+    LockBootLoader = ord("L")
+    SetStartupParams = ord("B")
+    GetStartupParams = ord("b")
+    ServerModeTickle = ord("D")
+    GetChipID = ord("U")
+
+
+class LEDS(int, Enum):
+    All = 0
+    Top = 1
+    Bottom = 2
+
+
+class Report(int, Enum):
+    One = 1
+    Two = 2
+
+
+class ReportField(BitField):
+    """8-bit report field."""
+
+    def __init__(self):
+        super().__init__(56, 8)
+
+
+class ActionField(BitField):
+    """8-bit action field."""
+
+    def __init__(self):
+        super().__init__(48, 8)
+
+
+class RedField(BitField):
+    """8-bit red field."""
+
+    def __init__(self):
+        super().__init__(40, 8)
+
+
+class GreenField(BitField):
+    """8-bit green field."""
+
+    def __init__(self):
+        super().__init__(32, 8)
+
+
+class BlueField(BitField):
+    """8-bit blue field."""
+
+    def __init__(self):
+        super().__init__(24, 8)
+
+
+class PlayField(BitField):
+    """8-bit play field."""
+
+    def __init__(self):
+        super().__init__(40, 8)
+
+
+class StartField(BitField):
+    """8-bit start field."""
+
+    def __init__(self):
+        super().__init__(32, 8)
+
+
+class StopField(BitField):
+    """8-bit stop field."""
+
+    def __init__(self):
+        super().__init__(24, 8)
+
+
+class CountField(BitField):
+    """8-bit count field."""
+
+    def __init__(self):
+        super().__init__(16, 8)
+
+
+class FadeField(BitField):
+    """16-bit fade field."""
+
+    def __init__(self):
+        super().__init__(8, 16)
+
+
+class LedsField(BitField):
+    """8-bit led field."""
+
+    def __init__(self):
+        super().__init__(0, 8)
+
+
+class LinesField(BitField):
+    """8-bit line field."""
+
+    def __init__(self):
+        super().__init__(0, 8)
+
+
+class State(Word):
+    def __init__(self):
+        super().__init__(0, 64)
+
+    report = ReportField()
+    action = ActionField()
+    red = RedField()
+    green = GreenField()
+    blue = BlueField()
+    play = PlayField()  # alias for red
+    start = StartField()  # alias for green
+    stop = StopField()  # alias for blue
+    count = CountField()
+    fade = FadeField()
+    leds = LedsField()
+    line = LinesField()  # alias for leds
+
+    @property
+    def color(self) -> tuple[int, int, int]:
+        return (self.red, self.green, self.blue)
+
+    @color.setter
+    def color(self, values: tuple[int, int, int]) -> None:
+        self.red, self.green, self.blue = values
+
+    def fade_to_color(
+        self,
+        color: tuple[int, int, int],
+        fade_ms: int = 10,
+        leds: LEDS = LEDS.All,
+    ) -> None:
+        self.clear()
+        self.report = Report.One
+        self.action = Action.FadeColor
+        self.color = color
+        self.fade = fade_ms
+        self.leds = leds
+
+    def write_pattern_line(
+        self,
+        color: tuple[int, int, int],
+        fade_ms: int,
+        index: int,
+    ) -> None:
+        self.clear()
+        self.report = Report.One
+        self.action = Action.SetColorPattern
+        self.color = color
+        self.fade = fade_ms
+        self.line = index
+
+    def save_patterns(self) -> None:
+        self.clear()
+        self.report = Report.One
+        self.action = Action.SaveColorPatterns
+        self.color = (0xBE, 0xEF, 0xCA)
+        self.count = 0xFE
+
+    def play_loop(self, play: int, start: int, stop: int, count: int = 0) -> None:
+        self.clear()
+        self.report = Report.One
+        self.action = Action.PlayLoop
+        self.play = play
+        self.start = start
+        self.stop = stop
+        self.count = count
+
+    def clear_patterns(self, start: int = 0, count: int = 16) -> None:
+        for index in range(start, start + count):
+            self.write_pattern_line((0, 0, 0), 0, index)

--- a/src/busylight_core/vendors/thingm/blink1.py
+++ b/src/busylight_core/vendors/thingm/blink1.py
@@ -1,0 +1,51 @@
+"""ThingM blink(1) Support"""
+
+from functools import cached_property
+from typing import Callable
+
+from loguru import logger
+
+from ...light import Light
+from ._blink1 import LEDS, Action, Report, State
+
+
+class Blink1(Light):
+    @staticmethod
+    def supported_device_ids() -> dict[tuple[int, int], str]:
+        return {
+            (0x27B8, 0x01ED): "Blink(1)",
+        }
+
+    @staticmethod
+    def vendor() -> str:
+        return "ThingM"
+
+    @cached_property
+    def state(self) -> State:
+        return State()
+
+    @property
+    def action(self) -> Action:
+        return getattr(self, "_action", Action.FadeColor)
+
+    @action.setter
+    def action(self, action: Action) -> None:
+        self._action = action
+
+    def __bytes__(self) -> bytes:
+
+        match self.action:
+            case Action.FadeColor:
+                self.state.fade_to_color(self.color)
+            case _:
+                raise NotImplementedError(f"Action {self.action} not implemented")
+        return bytes(self.state)
+
+    def on(self, color: tuple[int, int, int]) -> None:
+
+        self.action = Action.FadeColor
+        super().on(color)
+
+    @property
+    def write_strategy(self) -> Callable:
+        return self.hardware.handle.send_feature_report

--- a/src/busylight_core/word.py
+++ b/src/busylight_core/word.py
@@ -1,0 +1,82 @@
+""" """
+
+import array
+import struct
+
+
+class Word:
+    def __init__(self, value: int = 0, length: int = 8) -> None:
+
+        if length <= 0 or length % 8 != 0:
+            raise ValueError("length must be a multiple of 8")
+
+        self.initial_value = value
+        self.length = length
+        self.bits = array.array("B", [(value >> n) & 1 for n in self.range])
+
+    def __repr__(self) -> str:
+        return f"{self.__class__.__name__}(value={self.hex})"
+
+    def __str__(self) -> str:
+        return self.hex
+
+    @property
+    def value(self) -> int:
+        """Return the integer value of the word."""
+        return sum([b << n for n, b in enumerate(self.bits)])
+
+    @property
+    def range(self) -> range:
+        """Return the range of bit offsets for this word."""
+        return range(0, self.length)
+
+    @property
+    def hex(self) -> str:
+        return f"{self.value:#0{self.length // 4}x}"
+
+    @property
+    def bin(self) -> str:
+        return "0b" + bin(self.value)[2:].zfill(self.length)
+
+    def clear(self) -> None:
+        """Clear all bits in the word."""
+        self.bits = array.array("B", [0] * self.length)
+
+    def __bytes__(self) -> bytes:
+        return self.value.to_bytes(self.length // 8, byteorder="big")
+
+    def __getitem__(self, key: int | slice) -> int:
+        if isinstance(key, int):
+            if key not in self.range:
+                raise IndexError(f"Index out of range: {key}")
+            return self.bits[key]
+        return sum([b << n for n, b in enumerate(self.bits[key])])
+
+    def __setitem__(self, key: int | slice, value: bool | int) -> None:
+        if isinstance(key, int):
+            if key not in self.range:
+                raise IndexError(f"Index out of range: {key}")
+            self.bits[key] = value & 1
+            return
+        length = len(self.bits[key])
+        new_bits = array.array("B", [value >> n & 1 for n in range(length)])
+        self.bits[key] = new_bits
+
+
+class ReadOnlyBitField:
+    def __init__(self, offset: int, width: int = 1) -> None:
+        self.field = slice(offset, offset + width)
+
+    def __get__(self, obj, type=None) -> int:
+        return obj[self.field]
+
+    def __set_name__(self, owner, name: str) -> None:
+        self.name = name
+
+    def __set__(self, obj, value: int) -> None:
+        raise AttributeError(f"{self.name} attribute is read only")
+
+
+class BitField(ReadOnlyBitField):
+    def __set__(self, obj, value: int) -> None:
+        obj[self.field] = value

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,30 +1,75 @@
-"""Busylight Core for Humans pytest configuration file."""
+""" """
 
 from pathlib import Path
-
-import pytest
 import tomllib
+import pytest
+from busylight_core.hardware import ConnectionType, Hardware
+from serial.tools.list_ports_common import ListPortInfo
 
 
 @pytest.fixture(scope="session")
 def project_root() -> Path:
     """Return the root path of the project."""
-    return Path.cwd()
+    yield Path.cwd()
 
 
 @pytest.fixture(scope="session")
 def pyproject_path(project_root: Path) -> Path:
     """Return the path to the pyproject.toml file."""
-    return project_root / "pyproject.toml"
+    yield project_root / "pyproject.toml"
 
 
 @pytest.fixture(scope="session")
 def pyproject_toml(pyproject_path: Path) -> dict:
     """Return the contents of the pyproject.toml file."""
-    return tomllib.load(pyproject_path.open("rb"))
+    yield tomllib.load(pyproject_path.open("rb"))
 
 
 @pytest.fixture(scope="session")
 def project_version(pyproject_toml: dict) -> str:
     """Return the project version from pyproject.toml."""
     return pyproject_toml["project"]["version"]
+
+
+@pytest.fixture
+def serial_device_info() -> ListPortInfo:
+    info = ListPortInfo("/BOGUS/PATH")
+    info.description = "Test Port"
+    info.hwid = "USB VID:PID=9999:9999"
+    info.manufacturer = "Test Manufacturer"
+    info.product = "Test Product"
+    info.vid = 0x9999
+    info.pid = 0x9999
+    info.serial_number = "12345678"
+    return info
+
+
+@pytest.fixture
+def hid_device_info() -> dict:
+    return {
+        "path": b"/BOGUS/PATH",
+        "vendor_id": 0x9999,
+        "product_id": 0x9999,
+        "serial_number": "12345678",
+        "manufacturer_string": "Test Manufacturer",
+        "product_string": "Test Product",
+        "usage_page": 0x01,
+        "usage": 0x02,
+        "interface_number": 0,
+        "bus_type": 0,
+    }
+
+
+@pytest.fixture
+def hardware_hid_device(hid_device_info) -> Hardware:
+    return Hardware.from_hid(hid_device_info)
+
+
+@pytest.fixture
+def hardware_serial_device(serial_device_info) -> Hardware:
+    return Hardware.from_PortInfo(serial_device_info)
+
+
+@pytest.fixture
+def hardware_devices(hardware_hid_device, hardware_serial_device) -> list[Hardware]:
+    return [hardware_hid_device, hardware_serial_device]

--- a/tests/test_hardware.py
+++ b/tests/test_hardware.py
@@ -1,0 +1,95 @@
+"""
+"""
+
+import pytest
+from busylight_core.hardware import ConnectionType, Hardware
+from serial.tools import list_ports_common
+
+# test enumerate classmethod
+
+
+def test_hardware_classmethod_enumerate_without_args() -> None:
+
+    results = Hardware.enumerate()
+
+    assert isinstance(results, list)
+    for item in results:
+        assert isinstance(item, Hardware)
+
+
+@pytest.mark.parametrize(
+    "connection, implemented",
+    [
+        (ConnectionType.ANY, True),
+        (ConnectionType.UNKNOWN, False),
+        (ConnectionType.HID, True),
+        (ConnectionType.SERIAL, True),
+        (ConnectionType.BLUETOOTH, False),
+    ],
+)
+def test_hardware_classmethod_enumerate_by_connection_type(
+    connection,
+    implemented,
+) -> None:
+
+    if not implemented:
+        with pytest.raises(NotImplementedError):
+            results = Hardware.enumerate(connection)
+    else:
+        results = Hardware.enumerate(connection)
+
+        assert isinstance(results, list)
+        for item in results:
+            assert isinstance(item, Hardware)
+            assert item.device_type in ConnectionType
+
+
+def test_hardware_classmethod_from_portinfo(hardware_serial_device) -> None:
+
+    assert isinstance(hardware_serial_device, Hardware)
+    assert hardware_serial_device.vendor_id == 0x9999
+    assert hardware_serial_device.product_id == 0x9999
+    assert hardware_serial_device.serial_number == "12345678"
+    assert hardware_serial_device.device_type == ConnectionType.SERIAL
+    assert hardware_serial_device.bus_type == 1
+    assert "test" in hardware_serial_device.manufacturer_string.lower()
+    assert isinstance(hardware_serial_device.path, bytes)
+    assert hardware_serial_device.device_id == (
+        hardware_serial_device.vendor_id,
+        hardware_serial_device.product_id,
+    )
+
+
+def test_hardware_classmethod_from_hid(hardware_hid_device) -> None:
+
+    assert isinstance(hardware_hid_device, Hardware)
+    assert hardware_hid_device.vendor_id == 0x9999
+    assert hardware_hid_device.product_id == 0x9999
+    assert hardware_hid_device.serial_number == "12345678"
+    assert hardware_hid_device.device_type == ConnectionType.HID
+    assert hardware_hid_device.bus_type == 0
+    assert "test" in hardware_hid_device.manufacturer_string.lower()
+    assert "test" in hardware_hid_device.product_string.lower()
+    assert isinstance(hardware_hid_device.path, bytes)
+    assert hardware_hid_device.device_id == (
+        hardware_hid_device.vendor_id,
+        hardware_hid_device.product_id,
+    )
+
+
+@pytest.mark.skip(reason="Not implemented")
+@pytest.mark.parametrize("hardware", [None])
+def test_hardware_property_handle(hardware: Hardware) -> None:
+    pass
+
+
+@pytest.mark.skip(reason="Not implemented")
+@pytest.mark.parametrize("hardware", [None])
+def test_hardware_method_acquire(hardware: Hardware) -> None:
+    pass
+
+
+@pytest.mark.skip(reason="Not implemented")
+@pytest.mark.parametrize("hardware", [None])
+def test_hardware_method_release(hardware: Hardware) -> None:
+    pass

--- a/tests/test_hid.py
+++ b/tests/test_hid.py
@@ -1,0 +1,356 @@
+"""Tests for the hid module compatibility layer."""
+
+import pytest
+from unittest.mock import Mock, patch, MagicMock
+
+from busylight_core.hid import Device, enumerate
+
+
+class TestEnumerate:
+    """Tests for the enumerate function."""
+
+    def test_enumerate_returns_list_of_dicts(self):
+        """Test that enumerate returns a list of dictionaries."""
+        mock_device_info = [
+            {"vendor_id": 0x1234, "product_id": 0x5678, "path": b"/dev/hidraw0"},
+            {"vendor_id": 0x9999, "product_id": 0x8888, "path": b"/dev/hidraw1"},
+        ]
+        
+        with patch('busylight_core.hid.hid.enumerate', return_value=mock_device_info):
+            result = enumerate()
+            
+        assert isinstance(result, list)
+        assert len(result) == 2
+        for item in result:
+            assert isinstance(item, dict)
+            assert "vendor_id" in item
+            assert "product_id" in item
+            assert "path" in item
+
+    def test_enumerate_empty_list(self):
+        """Test enumerate with no devices."""
+        with patch('busylight_core.hid.hid.enumerate', return_value=[]):
+            result = enumerate()
+            
+        assert result == []
+
+
+class TestDeviceInitialization:
+    """Tests for Device initialization and library detection."""
+
+    def test_device_init_with_cython_hidapi(self):
+        """Test Device initialization with cython-hidapi (hid.device available)."""
+        mock_device = Mock()
+        
+        with patch('busylight_core.hid.hid.device', return_value=mock_device):
+            device = Device()
+            
+        assert device._handle is mock_device
+        assert device._is_open is False
+
+    def test_device_init_with_pyhidapi_fallback(self):
+        """Test Device initialization with pyhidapi fallback (hid.device not available)."""
+        with patch('busylight_core.hid.hid.device', side_effect=AttributeError):
+            device = Device()
+            
+        assert device._handle is None
+        assert device._is_open is False
+
+    def test_is_open_property(self):
+        """Test the is_open property."""
+        with patch('busylight_core.hid.hid.device', return_value=Mock()):
+            device = Device()
+            
+        assert device.is_open is False
+        device._is_open = True
+        assert device.is_open is True
+
+
+class TestDeviceErrorHandling:
+    """Tests for Device error handling."""
+
+    def test_error_property_normal_case(self):
+        """Test error property returns error from handle."""
+        mock_device = Mock()
+        mock_device.error.return_value = "Test error message"
+        
+        with patch('busylight_core.hid.hid.device', return_value=mock_device):
+            device = Device()
+            
+        assert device.error == "Test error message"
+        mock_device.error.assert_called_once()
+
+    def test_error_property_ioerror_case(self):
+        """Test error property handles IOError exception."""
+        mock_device = Mock()
+        mock_device.error.side_effect = IOError("Device not found")
+        
+        with patch('busylight_core.hid.hid.device', return_value=mock_device):
+            device = Device()
+            
+        assert device.error == "Device not found"
+
+
+class TestDeviceOpen:
+    """Tests for Device.open method."""
+
+    def test_open_with_cython_hidapi(self):
+        """Test opening device with cython-hidapi."""
+        mock_device = Mock()
+        
+        with patch('busylight_core.hid.hid.device', return_value=mock_device):
+            device = Device()
+            device.open(0x1234, 0x5678)
+            
+        mock_device.open.assert_called_once_with(0x1234, 0x5678, None)
+        assert device._is_open is True
+
+    def test_open_with_cython_hidapi_and_serial(self):
+        """Test opening device with cython-hidapi and serial number."""
+        mock_device = Mock()
+        
+        with patch('busylight_core.hid.hid.device', return_value=mock_device):
+            device = Device()
+            device.open(0x1234, 0x5678, "SERIAL123")
+            
+        mock_device.open.assert_called_once_with(0x1234, 0x5678, "SERIAL123")
+        assert device._is_open is True
+
+    def test_open_with_pyhidapi_fallback(self):
+        """Test opening device with pyhidapi fallback."""
+        mock_hid_device = Mock()
+        
+        with patch('busylight_core.hid.hid.device', side_effect=AttributeError), \
+             patch('busylight_core.hid.hid.Device', return_value=mock_hid_device, create=True) as mock_Device:
+            device = Device()
+            device.open(0x1234, 0x5678)
+            
+        # Check that hid.Device was called with correct parameters
+        mock_Device.assert_called_once_with(vid=0x1234, pid=0x5678, serial=None)
+        assert device._handle is mock_hid_device
+        assert device._is_open is True
+
+    def test_open_with_pyhidapi_fallback_and_serial(self):
+        """Test opening device with pyhidapi fallback and serial number."""
+        mock_hid_device = Mock()
+        
+        with patch('busylight_core.hid.hid.device', side_effect=AttributeError), \
+             patch('busylight_core.hid.hid.Device', return_value=mock_hid_device, create=True) as mock_Device:
+            device = Device()
+            device.open(0x1234, 0x5678, "SERIAL123")
+            
+        mock_Device.assert_called_once_with(vid=0x1234, pid=0x5678, serial="SERIAL123")
+        assert device._handle is mock_hid_device
+        assert device._is_open is True
+
+    def test_open_already_open_device(self):
+        """Test opening an already open device raises IOError."""
+        mock_device = Mock()
+        
+        with patch('busylight_core.hid.hid.device', return_value=mock_device):
+            device = Device()
+            device._is_open = True
+            
+            with pytest.raises(IOError, match="device already open"):
+                device.open(0x1234, 0x5678)
+
+
+class TestDeviceOpenPath:
+    """Tests for Device.open_path method."""
+
+    def test_open_path_with_bytes(self):
+        """Test opening device by path with bytes."""
+        mock_device = Mock()
+        test_path = b"/dev/hidraw0"
+        
+        with patch('busylight_core.hid.hid.device', return_value=mock_device):
+            device = Device()
+            device.open_path(test_path)
+            
+        mock_device.open_path.assert_called_once_with(test_path)
+        assert device._is_open is True
+
+    def test_open_path_with_string(self):
+        """Test opening device by path with string (converted to bytes)."""
+        mock_device = Mock()
+        test_path = "/dev/hidraw0"
+        
+        with patch('busylight_core.hid.hid.device', return_value=mock_device):
+            device = Device()
+            device.open_path(test_path)
+            
+        mock_device.open_path.assert_called_once_with(test_path.encode("utf-8"))
+        assert device._is_open is True
+
+    def test_open_path_with_pyhidapi_fallback(self):
+        """Test opening device by path with pyhidapi fallback."""
+        mock_hid_device = Mock()
+        test_path = b"/dev/hidraw0"
+        
+        with patch('busylight_core.hid.hid.device', side_effect=AttributeError), \
+             patch('busylight_core.hid.hid.Device', return_value=mock_hid_device, create=True) as mock_Device:
+            device = Device()
+            device.open_path(test_path)
+            
+        mock_Device.assert_called_once_with(path=test_path)
+        assert device._handle is mock_hid_device
+        assert device._is_open is True
+
+    def test_open_path_already_open_device(self):
+        """Test opening path on already open device raises IOError."""
+        mock_device = Mock()
+        
+        with patch('busylight_core.hid.hid.device', return_value=mock_device):
+            device = Device()
+            device._is_open = True
+            
+            with pytest.raises(IOError, match="device already open"):
+                device.open_path(b"/dev/hidraw0")
+
+
+class TestDeviceClose:
+    """Tests for Device.close method."""
+
+    def test_close_open_device(self):
+        """Test closing an open device."""
+        mock_device = Mock()
+        
+        with patch('busylight_core.hid.hid.device', return_value=mock_device):
+            device = Device()
+            device._is_open = True
+            device.close()
+            
+        mock_device.close.assert_called_once()
+        assert device._is_open is False
+
+    def test_close_not_open_device(self):
+        """Test closing a device that's not open raises IOError."""
+        mock_device = Mock()
+        mock_device.close.side_effect = AttributeError("close")
+        
+        with patch('busylight_core.hid.hid.device', return_value=mock_device):
+            device = Device()
+            device._is_open = True
+            
+            with pytest.raises(IOError, match="device not open"):
+                device.close()
+
+
+class TestDeviceOperations:
+    """Tests for Device I/O operations."""
+
+    def test_read_open_device(self):
+        """Test reading from an open device."""
+        mock_device = Mock()
+        mock_device.read.return_value = [0x01, 0x02, 0x03]
+        
+        with patch('busylight_core.hid.hid.device', return_value=mock_device):
+            device = Device()
+            device._is_open = True
+            
+            result = device.read(3)
+            
+        mock_device.read.assert_called_once_with(3, None)
+        assert result == [0x01, 0x02, 0x03]
+
+    def test_read_with_timeout(self):
+        """Test reading from device with timeout."""
+        mock_device = Mock()
+        mock_device.read.return_value = [0x01, 0x02, 0x03]
+        
+        with patch('busylight_core.hid.hid.device', return_value=mock_device):
+            device = Device()
+            device._is_open = True
+            
+            result = device.read(3, 1000)
+            
+        mock_device.read.assert_called_once_with(3, 1000)
+        assert result == [0x01, 0x02, 0x03]
+
+    def test_read_closed_device(self):
+        """Test reading from a closed device raises IOError."""
+        mock_device = Mock()
+        
+        with patch('busylight_core.hid.hid.device', return_value=mock_device):
+            device = Device()
+            device._is_open = False
+            
+            with pytest.raises(IOError, match="device not open"):
+                device.read(3)
+
+    def test_write_open_device(self):
+        """Test writing to an open device."""
+        mock_device = Mock()
+        mock_device.write.return_value = 3
+        test_data = b"\x01\x02\x03"
+        
+        with patch('busylight_core.hid.hid.device', return_value=mock_device):
+            device = Device()
+            device._is_open = True
+            
+            result = device.write(test_data)
+            
+        mock_device.write.assert_called_once_with(test_data)
+        assert result == 3
+
+    def test_write_closed_device(self):
+        """Test writing to a closed device raises IOError."""
+        mock_device = Mock()
+        
+        with patch('busylight_core.hid.hid.device', return_value=mock_device):
+            device = Device()
+            device._is_open = False
+            
+            with pytest.raises(IOError, match="device not open"):
+                device.write(b"\x01\x02\x03")
+
+    def test_get_feature_report_open_device(self):
+        """Test getting feature report from an open device."""
+        mock_device = Mock()
+        mock_device.get_feature_report.return_value = [0x01, 0x02, 0x03]
+        
+        with patch('busylight_core.hid.hid.device', return_value=mock_device):
+            device = Device()
+            device._is_open = True
+            
+            result = device.get_feature_report(1, 3)
+            
+        mock_device.get_feature_report.assert_called_once_with(1, 3)
+        assert result == [0x01, 0x02, 0x03]
+
+    def test_get_feature_report_closed_device(self):
+        """Test getting feature report from a closed device raises IOError."""
+        mock_device = Mock()
+        
+        with patch('busylight_core.hid.hid.device', return_value=mock_device):
+            device = Device()
+            device._is_open = False
+            
+            with pytest.raises(IOError, match="device not open"):
+                device.get_feature_report(1, 3)
+
+    def test_send_feature_report_open_device(self):
+        """Test sending feature report to an open device."""
+        mock_device = Mock()
+        mock_device.send_feature_report.return_value = 3
+        test_data = b"\x01\x02\x03"
+        
+        with patch('busylight_core.hid.hid.device', return_value=mock_device):
+            device = Device()
+            device._is_open = True
+            
+            result = device.send_feature_report(test_data)
+            
+        mock_device.send_feature_report.assert_called_once_with(test_data)
+        assert result == 3
+
+    def test_send_feature_report_closed_device(self):
+        """Test sending feature report to a closed device raises IOError."""
+        mock_device = Mock()
+        
+        with patch('busylight_core.hid.hid.device', return_value=mock_device):
+            device = Device()
+            device._is_open = False
+            
+            with pytest.raises(IOError, match="device not open"):
+                device.send_feature_report(b"\x01\x02\x03")

--- a/tests/test_implementation.py
+++ b/tests/test_implementation.py
@@ -1,0 +1,192 @@
+"""
+"""
+
+from typing import Callable
+
+import pytest
+from busylight_core import LightUnsupported, NoLightsFound
+from busylight_core.hardware import Hardware
+
+from .vendor_examples import HardwareCatalog as VENDOR_HARDWARE
+
+VENDOR_SUBCLASSES = VENDOR_HARDWARE.keys()
+
+
+@pytest.mark.parametrize("subclass", VENDOR_SUBCLASSES)
+def test_implementation_classmethod_supported_device_ids(subclass) -> None:
+
+    result = subclass.supported_device_ids()
+    assert isinstance(result, dict)
+
+    for key, value in result.items():
+        assert isinstance(key, tuple)
+        for item in key:
+            assert isinstance(item, int)
+        assert isinstance(value, str)
+
+
+@pytest.mark.parametrize("subclass", VENDOR_SUBCLASSES)
+def test_implementation_classmethod_vendor(subclass) -> None:
+
+    result = subclass.vendor()
+    assert isinstance(result, str)
+
+
+@pytest.mark.parametrize("subclass", VENDOR_SUBCLASSES)
+def test_implementation_classmethod_unique_device_names(subclass) -> None:
+
+    result = subclass.unique_device_names()
+    assert isinstance(result, list)
+
+    for item in result:
+        assert isinstance(item, str)
+
+
+@pytest.mark.parametrize("subclass,devices", list(VENDOR_HARDWARE.items()))
+def test_implementation_classmethod_claims(subclass, devices) -> None:
+
+    for device in devices:
+        result = subclass.claims(device)
+        assert isinstance(result, bool)
+        assert result is True
+
+
+@pytest.mark.parametrize("subclass", VENDOR_SUBCLASSES)
+def test_implementation_classmethod_does_not_claim_bogus(
+    subclass,
+    hardware_devices,
+) -> None:
+
+    for device in hardware_devices:
+        result = subclass.claims(device)
+        assert isinstance(result, bool)
+        assert result is False
+
+
+@pytest.mark.parametrize("subclass", VENDOR_SUBCLASSES)
+def test_implementation_classmethod_subclasses(subclass) -> None:
+
+    results = subclass.subclasses()
+    assert isinstance(results, list)
+    for item in results:
+        assert issubclass(item, subclass)
+
+
+@pytest.mark.parametrize("subclass", VENDOR_SUBCLASSES)
+def test_implementation_classmethod_supported_lights(subclass) -> None:
+
+    results = subclass.supported_lights()
+    assert isinstance(results, dict)
+    for key, value in results.items():
+        assert isinstance(key, str)
+        for item in value:
+            assert isinstance(item, str)
+
+
+@pytest.mark.parametrize("subclass", VENDOR_SUBCLASSES)
+def test_implementation_classmethod_available_lights(subclass) -> None:
+
+    results = subclass.available_lights()
+    assert isinstance(results, dict)
+    for subclasses, devices in results.items():
+        assert issubclass(subclasses, subclass)
+        assert isinstance(devices, list)
+        for device in devices:
+            assert isinstance(device, Hardware)
+
+
+@pytest.mark.parametrize("subclass", VENDOR_SUBCLASSES)
+def test_implementation_classmethod_all_lights(subclass) -> None:
+
+    results = subclass.all_lights()
+    assert isinstance(results, list)
+    for item in results:
+        assert isinstance(item, subclass)
+
+
+@pytest.mark.parametrize("subclass", VENDOR_SUBCLASSES)
+def test_implementation_classmethod_first_light(subclass) -> None:
+
+    try:
+        result = subclass.first_light()
+        assert isinstance(result, subclass)
+    except NoLightsFound:
+        pass
+
+
+@pytest.mark.parametrize("subclass", VENDOR_SUBCLASSES)
+def test_implementation_init_with_bogus_hardware(subclass, hardware_devices) -> None:
+
+    for device in hardware_devices:
+        with pytest.raises(LightUnsupported):
+            result = subclass(device, reset=False, exclusive=False)
+
+
+@pytest.mark.parametrize("subclass,devices", list(VENDOR_HARDWARE.items()))
+def test_implementation_init(subclass, devices) -> None:
+
+    for device in devices:
+
+        ## EJO The aquire and release methods are monkey patched here to
+        ##     to avoid really trying to acquire/release potentially bogus
+        ##     hardware devices.  Additionally, the write and read strategy
+        ##     methods are monkey patched to avoid any real I/O operations.
+
+        device.acquire = lambda: None
+        device.release = lambda: None
+
+        class TestSubclass(subclass):
+
+            @property
+            def write_strategy(self) -> Callable[[bytes], int]:
+                return lambda buf: None
+
+            @property
+            def read_strategy(self) -> Callable[[int, int | None], bytes]:
+                return lambda nbytes: b""
+
+        result = TestSubclass(device, reset=False, exclusive=False)
+
+        assert isinstance(result, subclass)
+
+        assert isinstance(result.hardware, Hardware)
+        assert result.hardware == device
+        assert result._reset is False
+        assert result._exclusive is False
+
+        assert isinstance(result._sort_key, tuple)
+        for item in result._sort_key:
+            assert isinstance(item, str)
+
+        assert isinstance(result.name, str)
+        assert isinstance(result.hex, str)
+        assert isinstance(result.read_strategy, Callable)
+        assert isinstance(result.write_strategy, Callable)
+
+        assert isinstance(bytes(result), bytes)
+
+        assert isinstance(result.red, int)
+        assert result.red == 0
+        assert isinstance(result.green, int)
+        assert result.green == 0
+        assert isinstance(result.blue, int)
+        assert result.blue == 0
+
+        assert isinstance(result.color, tuple)
+        assert all(c == 0 for c in result.color)
+
+        color = (255, 255, 255)
+
+        result.on(color)
+
+        assert all(c == 0xFF for c in result.color)
+        assert result.red == 0xFF
+        assert result.green == 0xFF
+        assert result.blue == 0xFF
+
+        result.off()
+
+        assert all(c == 0x00 for c in result.color)
+        assert result.red == 0x00
+        assert result.green == 0x00
+        assert result.blue == 0x00

--- a/tests/test_light.py
+++ b/tests/test_light.py
@@ -1,0 +1,99 @@
+"""
+"""
+
+import pytest
+from busylight_core import Light, NoLightsFound
+from busylight_core.hardware import Hardware
+
+
+def test_light_init_fails(hardware_devices: list[Hardware]) -> None:
+
+    for device in hardware_devices:
+        with pytest.raises(TypeError):
+            result = Light(device)
+
+
+def test_light_abstractclassmethod_supported_device_ids() -> None:
+
+    # EJO should this succeed?
+    with pytest.raises(NotImplementedError):
+        result = Light.supported_device_ids()
+
+
+def test_light_classmethod_vendor() -> None:
+
+    result = Light.vendor()
+    assert isinstance(result, str)
+
+
+def test_light_classmethod_unique_device_names() -> None:
+
+    # EJO should this succeed?
+    with pytest.raises(NotImplementedError):
+        result = Light.unique_device_names()
+
+
+def test_light_classmethod_claims_bogus_device(
+    hardware_devices: list[Hardware],
+) -> None:
+
+    for device in hardware_devices:
+        with pytest.raises(NotImplementedError):
+            result = Light.claims(device)
+
+
+def test_light_classmethod_subclasses() -> None:
+
+    results = Light.subclasses()
+
+    assert isinstance(results, list)
+
+    for item in results:
+        assert issubclass(item, Light)
+
+
+def test_light_classmethod_supported_lights() -> None:
+
+    results = Light.supported_lights()
+
+    assert isinstance(results, dict)
+
+    for vendor, product_names in results.items():
+        assert isinstance(vendor, str)
+        assert isinstance(product_names, list)
+
+        for product_name in product_names:
+            assert isinstance(product_name, str)
+
+
+def test_light_classmethod_available_lights() -> None:
+
+    results = Light.available_lights()
+
+    assert isinstance(results, dict)
+
+    for subclass, devices in results.items():
+        assert issubclass(subclass, Light)
+        assert isinstance(devices, list)
+
+        for device in devices:
+            assert isinstance(device, Hardware)
+
+
+def test_light_classmethod_all_lights() -> None:
+
+    results = Light.all_lights(reset=False, exclusive=False)
+
+    assert isinstance(results, list)
+
+    for item in results:
+        assert isinstance(item, Light)
+
+
+def test_light_classmethod_first_light() -> None:
+
+    try:
+        result = Light.first_light(reset=False, exclusive=False)
+        assert isinstance(result, Light)
+    except NoLightsFound:
+        pass

--- a/tests/test_light_comprehensive.py
+++ b/tests/test_light_comprehensive.py
@@ -1,0 +1,413 @@
+"""Comprehensive tests for the Light base class to improve coverage."""
+
+import pytest
+from unittest.mock import Mock, patch, MagicMock
+from contextlib import contextmanager
+
+from busylight_core.light import Light
+from busylight_core.hardware import Hardware, ConnectionType
+from busylight_core.exceptions import LightUnavailable, LightUnsupported, NoLightsFound
+
+
+class MockLightSubclass(Light):
+    """Mock Light subclass for testing."""
+    
+    @classmethod
+    def supported_device_ids(cls) -> dict[tuple[int, int], str]:
+        return {(0x1234, 0x5678): "MockLight"}
+    
+    def __bytes__(self) -> bytes:
+        return b'\x01\x02\x03\x04'
+
+
+def create_mock_hardware(vendor_id=0x1234, product_id=0x5678, path=b"/dev/hidraw0"):
+    """Create a mock hardware device."""
+    mock_hardware = Mock(spec=Hardware)
+    mock_hardware.device_id = (vendor_id, product_id)
+    mock_hardware.device_type = ConnectionType.HID
+    mock_hardware.path = path
+    mock_hardware.product_string = "MockLight"
+    mock_hardware.vendor_id = vendor_id
+    mock_hardware.product_id = product_id
+    mock_hardware.handle = Mock()
+    mock_hardware.handle.read = Mock(return_value=b'\x00\x01\x02\x03')
+    mock_hardware.handle.write = Mock()
+    mock_hardware.acquire = Mock()
+    mock_hardware.release = Mock()
+    return mock_hardware
+
+
+class TestLightFirstLight:
+    """Test first_light method coverage."""
+    
+    def test_first_light_with_exception_handling(self):
+        """Test first_light when subclass init raises exception - covers lines 115-117."""
+        mock_hardware = create_mock_hardware()
+        
+        with patch.object(MockLightSubclass, 'available_lights') as mock_available, \
+             patch.object(MockLightSubclass, '__init__', side_effect=Exception("Device initialization failed")):
+            
+            mock_available.return_value = {MockLightSubclass: [mock_hardware]}
+            
+            with pytest.raises(Exception, match="Device initialization failed"):
+                MockLightSubclass.first_light()
+
+
+class TestLightRepr:
+    """Test __repr__ method coverage."""
+    
+    def test_repr_method(self):
+        """Test __repr__ method - covers line 142."""
+        mock_hardware = create_mock_hardware()
+        
+        with patch.object(mock_hardware, 'acquire'), \
+             patch.object(MockLightSubclass, 'reset'):
+            light = MockLightSubclass(mock_hardware, reset=True, exclusive=True)
+            
+            repr_str = repr(light)
+            
+            assert "MockLightSubclass(" in repr_str
+            assert "reset=True" in repr_str
+            assert "exclusive=True" in repr_str
+
+
+class TestLightPath:
+    """Test path property coverage."""
+    
+    def test_path_property_cached(self):
+        """Test path property decode - covers line 153."""
+        mock_hardware = create_mock_hardware(path=b"/dev/hidraw1")
+        
+        with patch.object(mock_hardware, 'acquire'), \
+             patch.object(MockLightSubclass, 'reset'):
+            light = MockLightSubclass(mock_hardware)
+            
+            path = light.path
+            assert path == "/dev/hidraw1"
+            
+            # Test caching
+            path2 = light.path
+            assert path2 == "/dev/hidraw1"
+            assert path is path2
+
+
+class TestLightPlatform:
+    """Test platform property coverage."""
+    
+    def test_platform_property_windows(self):
+        """Test platform property for Windows - covers line 160."""
+        mock_hardware = create_mock_hardware()
+        
+        with patch.object(mock_hardware, 'acquire'), \
+             patch.object(MockLightSubclass, 'reset'), \
+             patch('busylight_core.light.platform.system', return_value="Windows"), \
+             patch('busylight_core.light.platform.release', return_value="10"):
+            
+            light = MockLightSubclass(mock_hardware)
+            platform = light.platform
+            
+            assert platform == "Windows_10"
+
+
+class TestLightSortKey:
+    """Test _sort_key property coverage."""
+    
+    def test_sort_key_property(self):
+        """Test _sort_key property - covers line 166."""
+        mock_hardware = create_mock_hardware()
+        
+        with patch.object(mock_hardware, 'acquire'), \
+             patch.object(MockLightSubclass, 'reset'), \
+             patch.object(MockLightSubclass, 'vendor', return_value="TestVendor"):
+            
+            light = MockLightSubclass(mock_hardware)
+            sort_key = light._sort_key
+            
+            assert isinstance(sort_key, tuple)
+            assert len(sort_key) == 3
+            assert sort_key[0] == "testvendor"  # vendor().lower()
+            assert sort_key[1] == "mocklight"   # name.lower()
+            assert sort_key[2] == "/dev/hidraw0" # path
+
+
+class TestLightEquality:
+    """Test __eq__ method coverage."""
+    
+    def test_eq_method_attribute_error(self):
+        """Test __eq__ method when other object lacks _sort_key - covers lines 169-172."""
+        mock_hardware = create_mock_hardware()
+        
+        with patch.object(mock_hardware, 'acquire'), \
+             patch.object(MockLightSubclass, 'reset'):
+            light = MockLightSubclass(mock_hardware)
+            
+            # Test with object that doesn't have _sort_key
+            class NoSortKeyObject:
+                pass
+            
+            other = NoSortKeyObject()
+            
+            # This should raise TypeError because NotImplemented is being raised incorrectly
+            with pytest.raises(TypeError):
+                light == other
+
+
+class TestLightComparison:
+    """Test __lt__ method coverage."""
+    
+    def test_lt_method_not_light_instance(self):
+        """Test __lt__ method with non-Light instance - covers lines 176-177."""
+        mock_hardware = create_mock_hardware()
+        
+        with patch.object(mock_hardware, 'acquire'), \
+             patch.object(MockLightSubclass, 'reset'):
+            light = MockLightSubclass(mock_hardware)
+            
+            # Test the actual __lt__ method directly to get NotImplemented
+            result = light.__lt__("not a light")
+            assert result is NotImplemented
+    
+    def test_lt_method_comparison_logic(self):
+        """Test __lt__ method comparison logic - covers lines 179-183."""
+        mock_hardware1 = create_mock_hardware(path=b"/dev/hidraw0")
+        mock_hardware2 = create_mock_hardware(path=b"/dev/hidraw1")
+        
+        with patch.object(mock_hardware1, 'acquire'), \
+             patch.object(mock_hardware2, 'acquire'), \
+             patch.object(MockLightSubclass, 'reset'):
+            
+            light1 = MockLightSubclass(mock_hardware1)
+            light2 = MockLightSubclass(mock_hardware2)
+            
+            # Test comparison - should compare based on _sort_key
+            result = light1 < light2
+            assert isinstance(result, bool)
+    
+    def test_lt_method_equal_sort_keys(self):
+        """Test __lt__ method when sort keys are equal - covers line 183."""
+        mock_hardware = create_mock_hardware()
+        
+        with patch.object(mock_hardware, 'acquire'), \
+             patch.object(MockLightSubclass, 'reset'):
+            light1 = MockLightSubclass(mock_hardware)
+            light2 = MockLightSubclass(mock_hardware)
+            
+            # Mock same sort keys
+            sort_key = ("vendor", "name", "/dev/hidraw0")
+            light1._sort_key = sort_key
+            light2._sort_key = sort_key
+            
+            result = light1 < light2
+            assert result is False
+
+
+class TestLightHash:
+    """Test __hash__ method coverage."""
+    
+    def test_hash_method_caching(self):
+        """Test __hash__ method caching - covers lines 186-191."""
+        mock_hardware = create_mock_hardware()
+        
+        with patch.object(mock_hardware, 'acquire'), \
+             patch.object(MockLightSubclass, 'reset'):
+            light = MockLightSubclass(mock_hardware)
+            
+            # First call should compute hash
+            hash1 = hash(light)
+            assert isinstance(hash1, int)
+            
+            # Second call should use cached value
+            hash2 = hash(light)
+            assert hash1 == hash2
+            
+            # Verify _hash attribute is set
+            assert hasattr(light, '_hash')
+            assert light._hash == hash1
+
+
+class TestLightHex:
+    """Test hex property coverage."""
+    
+    def test_hex_property(self):
+        """Test hex property - covers line 201."""
+        mock_hardware = create_mock_hardware()
+        
+        with patch.object(mock_hardware, 'acquire'), \
+             patch.object(MockLightSubclass, 'reset'):
+            light = MockLightSubclass(mock_hardware)
+            
+            hex_str = light.hex
+            assert isinstance(hex_str, str)
+            assert hex_str == "01:02:03:04"  # From MockLightSubclass.__bytes__
+
+
+class TestLightReadStrategy:
+    """Test read_strategy property coverage."""
+    
+    def test_read_strategy_property(self):
+        """Test read_strategy property - covers line 206."""
+        mock_hardware = create_mock_hardware()
+        
+        with patch.object(mock_hardware, 'acquire'), \
+             patch.object(MockLightSubclass, 'reset'):
+            light = MockLightSubclass(mock_hardware)
+            
+            read_strategy = light.read_strategy
+            assert read_strategy is mock_hardware.handle.read
+
+
+class TestLightExclusiveAccess:
+    """Test exclusive_access context manager coverage."""
+    
+    def test_exclusive_access_non_exclusive_mode(self):
+        """Test exclusive_access when not in exclusive mode - covers lines 222, 227."""
+        mock_hardware = create_mock_hardware()
+        
+        with patch.object(mock_hardware, 'acquire'), \
+             patch.object(MockLightSubclass, 'reset'):
+            # Create light in non-exclusive mode
+            light = MockLightSubclass(mock_hardware, exclusive=False)
+            light._exclusive = False
+            
+            with light.exclusive_access():
+                # Should acquire inside context
+                mock_hardware.acquire.assert_called()
+            
+            # Should release after context
+            mock_hardware.release.assert_called()
+
+
+class TestLightUpdate:
+    """Test update method coverage."""
+    
+    def test_update_windows_10_platform(self):
+        """Test update method with Windows 10 platform - covers line 236."""
+        mock_hardware = create_mock_hardware()
+        
+        with patch.object(mock_hardware, 'acquire'), \
+             patch.object(MockLightSubclass, 'reset'):
+            light = MockLightSubclass(mock_hardware)
+            
+            # Mock platform to be Windows_10
+            light.platform = "Windows_10"
+            
+            with patch.object(light, 'exclusive_access'):
+                light.update()
+                
+                # Should have called write_strategy with prepended zero byte
+                expected_data = bytes([0]) + b'\x01\x02\x03\x04'
+                mock_hardware.handle.write.assert_called_once_with(expected_data)
+    
+    def test_update_unsupported_platform(self):
+        """Test update method with unsupported platform - covers lines 239-240."""
+        mock_hardware = create_mock_hardware()
+        
+        with patch.object(mock_hardware, 'acquire'), \
+             patch.object(MockLightSubclass, 'reset'):
+            light = MockLightSubclass(mock_hardware)
+            
+            # Mock platform to be unsupported
+            light.platform = "UnsupportedOS_1.0"
+            
+            with patch.object(light, 'exclusive_access'), \
+                 patch('busylight_core.light.logger.info') as mock_logger:
+                light.update()
+                
+                # Should log unsupported OS message
+                mock_logger.assert_called_once_with("Unsupported OS UnsupportedOS_1.0, hoping for the best.")
+    
+    def test_update_write_strategy_exception(self):
+        """Test update method when write_strategy raises exception - covers lines 248-250."""
+        mock_hardware = create_mock_hardware()
+        
+        with patch.object(mock_hardware, 'acquire'), \
+             patch.object(MockLightSubclass, 'reset'):
+            light = MockLightSubclass(mock_hardware)
+            
+            # Mock write_strategy to raise exception
+            mock_hardware.handle.write.side_effect = Exception("Write failed")
+            
+            with patch.object(light, 'exclusive_access'), \
+                 patch('busylight_core.light.logger.error') as mock_logger:
+                
+                with pytest.raises(LightUnavailable):
+                    light.update()
+                
+                # Should log error
+                mock_logger.assert_called_once()
+
+
+class TestLightIntegration:
+    """Integration tests for Light class."""
+    
+    def test_complete_light_workflow(self):
+        """Test a complete workflow with Light class."""
+        mock_hardware = create_mock_hardware()
+        
+        with patch.object(mock_hardware, 'acquire'), \
+             patch.object(MockLightSubclass, 'reset'):
+            light = MockLightSubclass(mock_hardware)
+            
+            # Test various properties and methods
+            assert light.name == "MockLight"
+            assert light.vendor() == "Tests"  # From module path (tests.test_light_comprehensive)
+            assert isinstance(light.path, str)
+            assert isinstance(light.platform, str)
+            assert isinstance(light.hex, str)
+            assert callable(light.read_strategy)
+            assert callable(light.write_strategy)
+            
+            # Test context manager
+            with light.exclusive_access():
+                pass
+            
+            # Test update
+            light.update()
+            
+            # Test batch_update
+            with light.batch_update():
+                light.color = (255, 0, 0)
+            
+            # Test on/off
+            light.on((0, 255, 0))
+            light.off()
+            
+            # Test reset
+            light.reset()
+
+
+class TestLightEdgeCases:
+    """Test edge cases and error conditions."""
+    
+    def test_unsupported_hardware_initialization(self):
+        """Test Light initialization with unsupported hardware."""
+        # Create hardware that won't be claimed by MockLightSubclass
+        mock_hardware = create_mock_hardware(vendor_id=0x9999, product_id=0x9999)
+        
+        with pytest.raises(LightUnsupported):
+            MockLightSubclass(mock_hardware)
+    
+    def test_light_comparison_edge_cases(self):
+        """Test light comparison edge cases."""
+        mock_hardware1 = create_mock_hardware()
+        mock_hardware2 = create_mock_hardware()
+        
+        with patch.object(mock_hardware1, 'acquire'), \
+             patch.object(mock_hardware2, 'acquire'), \
+             patch.object(MockLightSubclass, 'reset'):
+            
+            light1 = MockLightSubclass(mock_hardware1)
+            light2 = MockLightSubclass(mock_hardware2)
+            
+            # Test equality
+            assert light1 == light1  # Same object
+            
+            # Test hash consistency
+            hash1 = hash(light1)
+            hash2 = hash(light1)
+            assert hash1 == hash2
+            
+            # Test sorting
+            lights = [light1, light2]
+            sorted_lights = sorted(lights)
+            assert len(sorted_lights) == 2

--- a/tests/test_luxafor_mute.py
+++ b/tests/test_luxafor_mute.py
@@ -1,0 +1,262 @@
+"""Tests for the Luxafor Mute device."""
+
+import pytest
+from unittest.mock import Mock, patch
+
+from busylight_core.vendors.luxafor.mute import Mute
+from busylight_core.hardware import Hardware, ConnectionType
+
+
+def create_mock_mute_hardware():
+    """Create a properly configured mock hardware for Mute device."""
+    mock_hardware = Mock(spec=Hardware)
+    mock_hardware.device_id = (0x4D8, 0xF372)
+    mock_hardware.device_type = ConnectionType.HID
+    mock_hardware.path = b"/dev/hidraw0"
+    mock_hardware.product_string = "Luxafor Mute"
+    mock_hardware.vendor_id = 0x4D8
+    mock_hardware.product_id = 0xF372
+    return mock_hardware
+
+
+class TestLuxaforMute:
+    """Test cases for Luxafor Mute device implementation."""
+
+    def test_supported_device_ids(self):
+        """Test that supported_device_ids returns correct device mapping."""
+        device_ids = Mute.supported_device_ids()
+        
+        assert isinstance(device_ids, dict)
+        assert (0x4D8, 0xF372) in device_ids
+        assert device_ids[(0x4D8, 0xF372)] == "Mute"
+
+    def test_is_button_property(self):
+        """Test that is_button property returns True for Mute device."""
+        mock_hardware = create_mock_mute_hardware()
+        
+        with patch.object(mock_hardware, 'acquire'), \
+             patch.object(Mute, 'reset'):
+            mute = Mute(mock_hardware)
+            assert mute.is_button is True
+
+    def test_button_on_response_66_sets_button_false(self):
+        """Test button_on when device response[0] == 66 sets _button to False."""
+        mock_hardware = create_mock_mute_hardware()
+        
+        with patch.object(mock_hardware, 'acquire'), \
+             patch.object(Mute, 'reset'), \
+             patch.object(Mute, 'read_strategy', return_value=[66, 0, 0, 0, 0, 0, 0, 0]) as mock_read:
+            mute = Mute(mock_hardware)
+            result = mute.button_on
+            
+            mock_read.assert_called_once_with(8, 200)
+            assert hasattr(mute, '_button')
+            assert mute._button is False
+            assert result is False  # Returns False after processing
+
+    def test_button_on_response_131_true(self):
+        """Test button_on when device response[0] == 131 and results[1] is truthy."""
+        mock_hardware = create_mock_mute_hardware()
+        
+        with patch.object(mock_hardware, 'acquire'), \
+             patch.object(Mute, 'reset'), \
+             patch.object(Mute, 'read_strategy', return_value=[131, 1, 0, 0, 0, 0, 0, 0]) as mock_read:
+            mute = Mute(mock_hardware)
+            result = mute.button_on
+            
+            mock_read.assert_called_once_with(8, 200)
+            assert result is True
+
+    def test_button_on_response_131_false(self):
+        """Test button_on when device response[0] == 131 and results[1] is falsy."""
+        mock_hardware = create_mock_mute_hardware()
+        
+        with patch.object(mock_hardware, 'acquire'), \
+             patch.object(Mute, 'reset'), \
+             patch.object(Mute, 'read_strategy', return_value=[131, 0, 0, 0, 0, 0, 0, 0]) as mock_read:
+            mute = Mute(mock_hardware)
+            result = mute.button_on
+            
+            mock_read.assert_called_once_with(8, 200)
+            assert result is False
+
+    def test_button_on_response_131_with_nonzero_value(self):
+        """Test button_on when device response[0] == 131 and results[1] has non-zero value."""
+        mock_hardware = create_mock_mute_hardware()
+        
+        with patch.object(mock_hardware, 'acquire'), \
+             patch.object(Mute, 'reset'), \
+             patch.object(Mute, 'read_strategy', return_value=[131, 255, 0, 0, 0, 0, 0, 0]) as mock_read:
+            mute = Mute(mock_hardware)
+            result = mute.button_on
+            
+            mock_read.assert_called_once_with(8, 200)
+            assert result is True
+
+    def test_button_on_index_error_handling(self):
+        """Test button_on handles IndexError gracefully and returns False."""
+        mock_hardware = create_mock_mute_hardware()
+        
+        with patch.object(mock_hardware, 'acquire'), \
+             patch.object(Mute, 'reset'), \
+             patch.object(Mute, 'read_strategy', return_value=[]) as mock_read:
+            mute = Mute(mock_hardware)
+            result = mute.button_on
+            
+            mock_read.assert_called_once_with(8, 200)
+            assert result is False
+
+    def test_button_on_index_error_with_short_response(self):
+        """Test button_on handles IndexError when response is too short."""
+        mock_hardware = create_mock_mute_hardware()
+        
+        with patch.object(mock_hardware, 'acquire'), \
+             patch.object(Mute, 'reset'), \
+             patch.object(Mute, 'read_strategy', return_value=[131]) as mock_read:  # Missing results[1]
+            mute = Mute(mock_hardware)
+            result = mute.button_on
+            
+            mock_read.assert_called_once_with(8, 200)
+            assert result is False
+
+    def test_button_on_unknown_response_code(self):
+        """Test button_on with unknown response code returns False."""
+        mock_hardware = create_mock_mute_hardware()
+        
+        with patch.object(mock_hardware, 'acquire'), \
+             patch.object(Mute, 'reset'), \
+             patch.object(Mute, 'read_strategy', return_value=[99, 1, 0, 0, 0, 0, 0, 0]) as mock_read:
+            mute = Mute(mock_hardware)
+            result = mute.button_on
+            
+            mock_read.assert_called_once_with(8, 200)
+            assert result is False
+
+
+class TestLuxaforMuteInheritance:
+    """Test inheritance and integration aspects of Luxafor Mute."""
+
+    def test_inherits_from_flag(self):
+        """Test that Mute properly inherits from Flag class."""
+        from busylight_core.vendors.luxafor.flag import Flag
+        
+        assert issubclass(Mute, Flag)
+        
+        # Test that Mute has all the Flag methods
+        mute_methods = dir(Mute)
+        flag_methods = dir(Flag)
+        
+        # Key Flag methods should be available in Mute
+        expected_methods = ['claims', 'state', '__bytes__', 'supported_device_ids']
+        for method in expected_methods:
+            assert method in mute_methods
+
+    def test_device_claiming_logic(self):
+        """Test that Mute can properly claim devices using inherited logic."""
+        mock_hardware = create_mock_mute_hardware()
+        
+        result = Mute.claims(mock_hardware)
+        assert result is True
+
+    def test_device_claiming_wrong_device(self):
+        """Test that Mute rejects devices it doesn't support."""
+        # Create a mock hardware that should NOT be claimed by Mute
+        mock_hardware = Mock(spec=Hardware)
+        mock_hardware.vendor_id = 0x1234
+        mock_hardware.product_id = 0x5678
+        mock_hardware.device_id = (0x1234, 0x5678)
+        mock_hardware.product_string = "Other Device"
+        
+        result = Mute.claims(mock_hardware)
+        assert result is False
+
+    def test_bytes_conversion_inheritance(self):
+        """Test that __bytes__ method works through inheritance."""
+        mock_hardware = create_mock_mute_hardware()
+        
+        with patch.object(mock_hardware, 'acquire'), \
+             patch.object(Mute, 'reset'), \
+             patch.object(Mute, 'color', (255, 0, 0)):  # Red color
+            mute = Mute(mock_hardware)
+            
+            # This should not raise an exception and should return bytes
+            result = bytes(mute)
+            assert isinstance(result, bytes)
+
+    def test_mute_specific_properties_override(self):
+        """Test that Mute-specific properties properly override Flag properties."""
+        mock_hardware = create_mock_mute_hardware()
+        
+        with patch.object(mock_hardware, 'acquire'), \
+             patch.object(Mute, 'reset'):
+            mute = Mute(mock_hardware)
+            
+            # Mute should override is_button to return True
+            assert mute.is_button is True
+            
+            # Mute should have button_on property (not in base Flag)
+            # Check that the property exists in the class, not the instance to avoid calling it
+            assert 'button_on' in dir(Mute)
+            assert isinstance(getattr(Mute, 'button_on'), property)
+
+
+class TestLuxaforMuteEdgeCases:
+    """Test edge cases and error conditions for Luxafor Mute."""
+
+    def test_button_on_read_strategy_exception(self):
+        """Test button_on when read_strategy raises an exception."""
+        mock_hardware = create_mock_mute_hardware()
+        
+        with patch.object(mock_hardware, 'acquire'), \
+             patch.object(Mute, 'reset'), \
+             patch.object(Mute, 'read_strategy', side_effect=Exception("Device communication error")):
+            mute = Mute(mock_hardware)
+            
+            # Should not crash, but may raise the exception or return a default value
+            # The current implementation doesn't handle this case, so it will raise
+            with pytest.raises(Exception, match="Device communication error"):
+                mute.button_on
+
+    def test_button_on_none_response(self):
+        """Test button_on when read_strategy returns None."""
+        mock_hardware = create_mock_mute_hardware()
+        
+        with patch.object(mock_hardware, 'acquire'), \
+             patch.object(Mute, 'reset'), \
+             patch.object(Mute, 'read_strategy', return_value=None):
+            mute = Mute(mock_hardware)
+            
+            # This will likely cause a TypeError when trying to access None[0]
+            with pytest.raises(TypeError):
+                mute.button_on
+
+    def test_multiple_button_reads(self):
+        """Test multiple sequential button reads behave consistently."""
+        mock_hardware = create_mock_mute_hardware()
+        
+        responses = [
+            [131, 1, 0, 0, 0, 0, 0, 0],  # Button pressed
+            [131, 0, 0, 0, 0, 0, 0, 0],  # Button released
+            [66, 0, 0, 0, 0, 0, 0, 0],   # Status response
+        ]
+        
+        with patch.object(mock_hardware, 'acquire'), \
+             patch.object(Mute, 'reset'), \
+             patch.object(Mute, 'read_strategy', side_effect=responses) as mock_read:
+            mute = Mute(mock_hardware)
+            
+            # First read - button pressed
+            assert mute.button_on is True
+            
+            # Second read - button released  
+            assert mute.button_on is False
+            
+            # Third read - status response, sets _button = False
+            result = mute.button_on
+            assert result is False
+            assert mute._button is False
+            
+            # Verify all calls were made with correct parameters
+            assert mock_read.call_count == 3
+            for call in mock_read.call_args_list:
+                assert call[0] == (8, 200)

--- a/tests/test_taskable_mixin.py
+++ b/tests/test_taskable_mixin.py
@@ -11,33 +11,39 @@ class TestTaskableMixin:
     """Test cases for TaskableMixin functionality."""
 
     def test_event_loop_property(self):
-        """Test that event_loop property returns the default event loop."""
+        """Test that event_loop property returns an event loop."""
         mixin = TaskableMixin()
         
-        with patch('asyncio.get_event_loop') as mock_get_loop:
+        with patch('asyncio.get_running_loop') as mock_get_running, \
+             patch('asyncio.new_event_loop') as mock_new_loop:
             mock_loop = Mock()
-            mock_get_loop.return_value = mock_loop
+            mock_get_running.side_effect = RuntimeError("no running loop")
+            mock_new_loop.return_value = mock_loop
             
             # Access the property to trigger the call
             result = mixin.event_loop
             
-            mock_get_loop.assert_called_once()
+            mock_get_running.assert_called_once()
+            mock_new_loop.assert_called_once()
             assert result is mock_loop
 
     def test_event_loop_cached_property(self):
-        """Test that event_loop is cached and only calls get_event_loop once."""
+        """Test that event_loop is cached and only calls event loop functions once."""
         mixin = TaskableMixin()
         
-        with patch('asyncio.get_event_loop') as mock_get_loop:
+        with patch('asyncio.get_running_loop') as mock_get_running, \
+             patch('asyncio.new_event_loop') as mock_new_loop:
             mock_loop = Mock()
-            mock_get_loop.return_value = mock_loop
+            mock_get_running.side_effect = RuntimeError("no running loop")
+            mock_new_loop.return_value = mock_loop
             
             # Access the property multiple times
             result1 = mixin.event_loop
             result2 = mixin.event_loop
             
-            # Should only call get_event_loop once due to caching
-            mock_get_loop.assert_called_once()
+            # Should only call event loop functions once due to caching
+            mock_get_running.assert_called_once()
+            mock_new_loop.assert_called_once()
             assert result1 is mock_loop
             assert result2 is mock_loop
             assert result1 is result2

--- a/tests/test_taskable_mixin.py
+++ b/tests/test_taskable_mixin.py
@@ -1,0 +1,357 @@
+"""Tests for the TaskableMixin class."""
+
+import asyncio
+import pytest
+from unittest.mock import Mock, patch, AsyncMock
+
+from busylight_core.mixins.taskable import TaskableMixin
+
+
+class TestTaskableMixin:
+    """Test cases for TaskableMixin functionality."""
+
+    def test_event_loop_property(self):
+        """Test that event_loop property returns the default event loop."""
+        mixin = TaskableMixin()
+        
+        with patch('asyncio.get_event_loop') as mock_get_loop:
+            mock_loop = Mock()
+            mock_get_loop.return_value = mock_loop
+            
+            # Access the property to trigger the call
+            result = mixin.event_loop
+            
+            mock_get_loop.assert_called_once()
+            assert result is mock_loop
+
+    def test_event_loop_cached_property(self):
+        """Test that event_loop is cached and only calls get_event_loop once."""
+        mixin = TaskableMixin()
+        
+        with patch('asyncio.get_event_loop') as mock_get_loop:
+            mock_loop = Mock()
+            mock_get_loop.return_value = mock_loop
+            
+            # Access the property multiple times
+            result1 = mixin.event_loop
+            result2 = mixin.event_loop
+            
+            # Should only call get_event_loop once due to caching
+            mock_get_loop.assert_called_once()
+            assert result1 is mock_loop
+            assert result2 is mock_loop
+            assert result1 is result2
+
+    def test_tasks_property_initial_state(self):
+        """Test that tasks property returns empty dict initially."""
+        mixin = TaskableMixin()
+        
+        assert isinstance(mixin.tasks, dict)
+        assert len(mixin.tasks) == 0
+
+    def test_tasks_cached_property(self):
+        """Test that tasks property is cached and returns same dict."""
+        mixin = TaskableMixin()
+        
+        tasks1 = mixin.tasks
+        tasks2 = mixin.tasks
+        
+        assert tasks1 is tasks2
+        assert isinstance(tasks1, dict)
+
+    def test_add_task_new_task(self):
+        """Test adding a new task creates and stores it."""
+        mixin = TaskableMixin()
+        mock_task = Mock()
+        mock_loop = Mock()
+        mock_loop.create_task.return_value = mock_task
+        
+        # Mock coroutine function
+        async def mock_coroutine(self):
+            return "test_result"
+        
+        with patch.object(mixin, 'event_loop', mock_loop):
+            result = mixin.add_task("test_task", mock_coroutine)
+            
+        # Verify task was created and stored
+        mock_loop.create_task.assert_called_once()
+        assert result is mock_task
+        assert mixin.tasks["test_task"] is mock_task
+
+    def test_add_task_existing_task_returns_existing(self):
+        """Test adding task with existing name returns existing task."""
+        mixin = TaskableMixin()
+        existing_task = Mock()
+        mixin.tasks["existing_task"] = existing_task
+        
+        # Mock coroutine function
+        async def mock_coroutine(self):
+            return "test_result"
+        
+        mock_loop = Mock()
+        with patch.object(mixin, 'event_loop', mock_loop):
+            result = mixin.add_task("existing_task", mock_coroutine)
+            
+        # Should return existing task without creating new one
+        assert result is existing_task
+        mock_loop.create_task.assert_not_called()
+
+    def test_add_task_coroutine_called_with_self(self):
+        """Test that coroutine is called with self when creating task."""
+        mixin = TaskableMixin()
+        mock_task = Mock()
+        mock_loop = Mock()
+        mock_loop.create_task.return_value = mock_task
+        
+        # Mock coroutine function that records its argument
+        coroutine_args = []
+        async def mock_coroutine(arg):
+            coroutine_args.append(arg)
+            return "test_result"
+        
+        with patch.object(mixin, 'event_loop', mock_loop):
+            mixin.add_task("test_task", mock_coroutine)
+            
+        # Verify the coroutine was called with self
+        mock_loop.create_task.assert_called_once()
+        call_args = mock_loop.create_task.call_args[0][0]
+        # The argument should be a coroutine, we can't easily verify the mixin
+        # was passed but we can verify create_task was called
+
+    def test_cancel_task_existing_task(self):
+        """Test canceling an existing task."""
+        mixin = TaskableMixin()
+        mock_task = Mock()
+        mixin.tasks["test_task"] = mock_task
+        
+        result = mixin.cancel_task("test_task")
+        
+        # Verify task was cancelled and removed
+        mock_task.cancel.assert_called_once()
+        assert result is mock_task
+        assert "test_task" not in mixin.tasks
+
+    def test_cancel_task_nonexistent_task(self):
+        """Test canceling a non-existent task returns None."""
+        mixin = TaskableMixin()
+        
+        result = mixin.cancel_task("nonexistent_task")
+        
+        assert result is None
+        assert len(mixin.tasks) == 0
+
+    def test_cancel_task_keyerror_handling(self):
+        """Test cancel_task handles KeyError gracefully."""
+        mixin = TaskableMixin()
+        
+        # Explicitly test KeyError path
+        result = mixin.cancel_task("missing_task")
+        
+        assert result is None
+
+    def test_cancel_task_attributeerror_handling(self):
+        """Test cancel_task handles AttributeError gracefully."""
+        mixin = TaskableMixin()
+        
+        # Create a mock task that raises AttributeError on cancel
+        mock_task = Mock()
+        mock_task.cancel.side_effect = AttributeError("cancel method not found")
+        mixin.tasks["problematic_task"] = mock_task
+        
+        result = mixin.cancel_task("problematic_task")
+        
+        # Should handle the AttributeError and return None
+        assert result is None
+        # Task should still be removed from tasks dict
+        assert "problematic_task" not in mixin.tasks
+
+    def test_cancel_tasks_empty_tasks(self):
+        """Test cancel_tasks with no tasks does nothing."""
+        mixin = TaskableMixin()
+        
+        # Should not raise any errors
+        mixin.cancel_tasks()
+        
+        assert len(mixin.tasks) == 0
+
+    def test_cancel_tasks_with_multiple_tasks(self):
+        """Test cancel_tasks cancels all tasks and clears dict."""
+        mixin = TaskableMixin()
+        
+        # Create multiple mock tasks
+        mock_task1 = Mock()
+        mock_task2 = Mock()
+        mock_task3 = Mock()
+        
+        mixin.tasks["task1"] = mock_task1
+        mixin.tasks["task2"] = mock_task2
+        mixin.tasks["task3"] = mock_task3
+        
+        mixin.cancel_tasks()
+        
+        # Verify all tasks were cancelled
+        mock_task1.cancel.assert_called_once()
+        mock_task2.cancel.assert_called_once()
+        mock_task3.cancel.assert_called_once()
+        
+        # Verify tasks dict is cleared
+        assert len(mixin.tasks) == 0
+
+    def test_cancel_tasks_with_task_cancel_error(self):
+        """Test cancel_tasks raises exception when task.cancel() fails."""
+        mixin = TaskableMixin()
+        
+        # Create tasks, one that raises error on cancel
+        mock_task1 = Mock()
+        mock_task2 = Mock()
+        mock_task2.cancel.side_effect = Exception("Cancel failed")
+        
+        mixin.tasks["task1"] = mock_task1
+        mixin.tasks["task2"] = mock_task2
+        
+        # Should raise exception when task2 cancel fails
+        with pytest.raises(Exception, match="Cancel failed"):
+            mixin.cancel_tasks()
+        
+        # Verify first task had cancel called
+        mock_task1.cancel.assert_called_once()
+        mock_task2.cancel.assert_called_once()
+        
+        # Verify tasks dict is NOT cleared when there's an error
+        # (the current implementation doesn't clear on error)
+        assert len(mixin.tasks) == 2
+
+
+class TestTaskableMixinIntegration:
+    """Integration tests for TaskableMixin with real asyncio."""
+
+    @pytest.mark.asyncio
+    async def test_real_asyncio_integration(self):
+        """Test TaskableMixin with actual asyncio tasks."""
+        mixin = TaskableMixin()
+        
+        # Create a real coroutine
+        async def test_coroutine(self):
+            await asyncio.sleep(0.1)
+            return "completed"
+        
+        # Add a task
+        task = mixin.add_task("real_task", test_coroutine)
+        
+        # Verify it's a real asyncio task
+        assert isinstance(task, asyncio.Task)
+        assert "real_task" in mixin.tasks
+        
+        # Cancel the task
+        cancelled_task = mixin.cancel_task("real_task")
+        
+        assert cancelled_task is task
+        assert "real_task" not in mixin.tasks
+        
+        # Wait a bit for cancellation to take effect
+        await asyncio.sleep(0.01)
+        assert task.cancelled()
+
+    @pytest.mark.asyncio
+    async def test_multiple_real_tasks(self):
+        """Test managing multiple real asyncio tasks."""
+        mixin = TaskableMixin()
+        
+        # Create multiple coroutines
+        async def slow_task(self):
+            await asyncio.sleep(0.2)
+            return "slow_completed"
+        
+        async def fast_task(self):
+            await asyncio.sleep(0.05)
+            return "fast_completed"
+        
+        # Add multiple tasks
+        slow = mixin.add_task("slow", slow_task)
+        fast = mixin.add_task("fast", fast_task)
+        
+        assert len(mixin.tasks) == 2
+        
+        # Cancel all tasks
+        mixin.cancel_tasks()
+        
+        assert len(mixin.tasks) == 0
+        
+        # Wait a bit for cancellation to take effect
+        await asyncio.sleep(0.01)
+        assert slow.cancelled()
+        assert fast.cancelled()
+
+    def test_event_loop_property_with_real_loop(self):
+        """Test event_loop property returns actual event loop."""
+        mixin = TaskableMixin()
+        
+        # Get the actual event loop
+        loop = mixin.event_loop
+        
+        # Should be a real event loop
+        assert isinstance(loop, asyncio.AbstractEventLoop)
+        
+        # Should be cached
+        loop2 = mixin.event_loop
+        assert loop is loop2
+
+
+class TestTaskableMixinEdgeCases:
+    """Test edge cases and error conditions."""
+
+    def test_tasks_property_modification(self):
+        """Test that tasks dict can be modified and persists."""
+        mixin = TaskableMixin()
+        
+        # Modify the tasks dict directly
+        mock_task = Mock()
+        mixin.tasks["manual_task"] = mock_task
+        
+        # Verify the modification persists
+        assert mixin.tasks["manual_task"] is mock_task
+        
+        # Verify it's still the same cached dict
+        tasks_ref = mixin.tasks
+        tasks_ref["another_task"] = Mock()
+        assert "another_task" in mixin.tasks
+
+    def test_add_task_with_none_coroutine(self):
+        """Test add_task behavior with None coroutine."""
+        mixin = TaskableMixin()
+        
+        # This should raise an error when trying to call None
+        with pytest.raises(TypeError):
+            mixin.add_task("bad_task", None)
+
+    def test_cancel_task_with_none_in_tasks(self):
+        """Test cancel_task when tasks dict contains None."""
+        mixin = TaskableMixin()
+        
+        # Manually put None in tasks (shouldn't happen in normal use)
+        mixin.tasks["none_task"] = None
+        
+        # This should trigger AttributeError handling
+        result = mixin.cancel_task("none_task")
+        
+        assert result is None
+        assert "none_task" not in mixin.tasks
+
+    def test_concurrent_task_operations(self):
+        """Test that concurrent operations on tasks work correctly."""
+        mixin = TaskableMixin()
+        
+        # Add some tasks
+        mock_task1 = Mock()
+        mock_task2 = Mock()
+        mixin.tasks["task1"] = mock_task1
+        mixin.tasks["task2"] = mock_task2
+        
+        # Simulate concurrent cancel operations
+        result1 = mixin.cancel_task("task1")
+        result2 = mixin.cancel_task("task1")  # Try to cancel same task again
+        
+        assert result1 is mock_task1
+        assert result2 is None  # Second cancel should return None
+        assert "task1" not in mixin.tasks
+        assert "task2" in mixin.tasks  # Other task should be unaffected

--- a/tests/test_word.py
+++ b/tests/test_word.py
@@ -1,0 +1,122 @@
+"""
+"""
+
+import pytest
+from busylight_core.word import BitField, ReadOnlyBitField, Word
+
+
+@pytest.mark.parametrize("length", [8, 16, 32, 64])
+def test_word_init(length: int) -> None:
+
+    value = 1 << length - 1
+    result = Word(value, length)
+    assert isinstance(result, Word)
+    assert result.length == length
+    assert result.value == value
+    assert isinstance(result.hex, str)
+    assert isinstance(result.bin, str)
+    assert isinstance(bytes(result), bytes)
+
+
+@pytest.mark.parametrize("length", [8, 16, 32, 64])
+def test_word_init_initializer_too_long(length: int) -> None:
+
+    value = 1 << length
+    result = Word(value, length)
+    assert isinstance(result, Word)
+    assert result.length == length
+    assert result.value == 0
+
+
+@pytest.mark.parametrize("value", list(range(1, 256, 16)))
+def test_word_method_clear(value) -> None:
+
+    result = Word(value, 8)
+
+    assert result.value == value
+
+    result.clear()
+
+    assert result.value == 0
+
+
+@pytest.mark.parametrize("value", [0, 0xFF])
+def test_word_dunder_bytes(value) -> None:
+
+    results = Word(0, 8)
+
+    assert isinstance(bytes(results), bytes)
+
+
+@pytest.mark.parametrize("value, expected", [(0, 0), (0xFF, 1)])
+def test_word_dunder_getitem(value, expected) -> None:
+
+    result = Word(value, 8)
+
+    for i in result.range:
+        assert result[i] == expected
+
+
+def test_word_dunder_setitem() -> None:
+
+    result = Word(0, 8)
+
+    assert result.value == 0
+
+    for i in result.range:
+        result[i] = 1
+        assert result.value & 1 << i
+
+
+def test_word_with_ReadOnlyBitField() -> None:
+
+    class TestWord(Word):
+        readonly = ReadOnlyBitField(0, 8)
+
+    result = TestWord(0, 8)
+
+    assert result.readonly == 0
+
+    with pytest.raises(AttributeError):
+        result.readonly = 1
+
+
+@pytest.mark.parametrize("value, expected", [(0, 0), (0xFF, 0xFF)])
+def test_word_with_BitField(value, expected) -> None:
+
+    class TestWord(Word):
+        field = BitField(0, 8)
+
+    result = TestWord(value, 8)
+
+    assert result.field == expected
+
+    result.field = 1
+
+    assert result.field == 1
+
+
+def test_word_with_BitField_and_ReadOnlyBitField() -> None:
+
+    class TestWord(Word):
+        field = BitField(0, 4)
+        readonly = ReadOnlyBitField(4, 4)
+
+    result = TestWord(0, 8)
+
+    assert result.field == 0
+    assert result.readonly == 0
+
+    result.field = 1
+
+    assert result.field == 1
+
+    with pytest.raises(AttributeError):
+        result.readonly = 1
+
+
+@pytest.mark.parametrize("length", [0, 1, 2, 3, 4, 5, 6, 7, 9, 10, 11, 12])
+def test_word_with_invalid_length(length: int) -> None:
+
+    with pytest.raises(ValueError):
+        Word(0, length)

--- a/tests/vendor_examples/__init__.py
+++ b/tests/vendor_examples/__init__.py
@@ -1,0 +1,37 @@
+"""
+"""
+
+from .agile_innovative import AGILE_INNOVATIVE_HARDWARE
+from .compulab import COMPULAB_HARDWARE
+from .embrava import EMBRAVA_HARDWARE
+from .kuando import KUANDO_HARDWARE
+from .luxafor import LUXAFOR_HARDWARE
+from .muteme import MUTEME_HARDWARE
+from .mutesync import MUTESYNC_HARDWARE
+from .plantronics import PLANTRONICS_HARDWARE
+from .thingm import THINGM_HARDWARE
+
+HardwareCatalog = (
+    AGILE_INNOVATIVE_HARDWARE
+    | COMPULAB_HARDWARE
+    | EMBRAVA_HARDWARE
+    | KUANDO_HARDWARE
+    | LUXAFOR_HARDWARE
+    | MUTEME_HARDWARE
+    | MUTESYNC_HARDWARE
+    | PLANTRONICS_HARDWARE
+    | THINGM_HARDWARE
+)
+
+__all__ = [
+    "HardwareCatalog",
+    "AGILE_INNOVATIVE_HARDWARE",
+    "COMPULAB_HARDWARE",
+    "EMBRAVA_HARDWARE",
+    "KUANDO_HARDWARE",
+    "LUXAFOR_HARDWARE",
+    "MUTEME_HARDWARE",
+    "MUTESYNC_HARDWARE",
+    "PLANTRONICS_HARDWARE",
+    "THINGM_HARDWARE",
+]

--- a/tests/vendor_examples/agile_innovative.py
+++ b/tests/vendor_examples/agile_innovative.py
@@ -1,0 +1,22 @@
+"""
+"""
+
+from busylight_core.vendors.agile_innovative import BlinkStick
+
+from .utils import make_hardware
+
+blinkstick_square_template = {
+    "path": b"/BOGUS/PATH",
+    "serial_number": "BS032974-3.0",
+    "release_number": 512,
+    "manufacturer_string": "Agile Innovative Ltd",
+    "product_string": "BlinkStick",
+    "usage_page": 65280,
+    "usage": 1,
+    "interface_number": 0,
+    "bus_type": 1,
+}
+
+AGILE_INNOVATIVE_HARDWARE = {
+    BlinkStick: make_hardware(BlinkStick, blinkstick_square_template),
+}

--- a/tests/vendor_examples/compulab.py
+++ b/tests/vendor_examples/compulab.py
@@ -1,0 +1,21 @@
+"""
+"""
+
+from busylight_core.hardware import ConnectionType
+from busylight_core.vendors.compulab import Fit_StatUSB
+
+from .utils import make_hardware
+
+fit_statusb_template = {
+    "device_type": ConnectionType.SERIAL,
+    "path": b"/BOGUS/PATH",
+    "serial_number": "193F914722000800",
+    "manufacturer_string": "Compulab LTD",
+    "product_string": "fit_StatUSB",
+    "bus_type": 1,
+}
+
+
+COMPULAB_HARDWARE = {
+    Fit_StatUSB: make_hardware(Fit_StatUSB, fit_statusb_template),
+}

--- a/tests/vendor_examples/embrava.py
+++ b/tests/vendor_examples/embrava.py
@@ -1,0 +1,49 @@
+"""
+"""
+
+from busylight_core.vendors.embrava import Blynclight, Blynclight_Mini, Blynclight_Plus
+
+from .utils import make_hardware
+
+blynclight_template = {
+    "path": b"/BOGUS/PATH",
+    "serial_number": "",
+    "release_number": 256,
+    "manufacturer_string": "",
+    "product_string": "Blynclight",
+    "usage_page": 65280,
+    "usage": 1,
+    "interface_number": 0,
+    "bus_type": 1,
+}
+
+blynclight_mini_template = {
+    "path": b"/BOGUS/PATH",
+    "serial_number": "",
+    "release_number": 256,
+    "manufacturer_string": "",
+    "product_string": "Blynclight Mini",
+    "usage_page": 65280,
+    "usage": 1,
+    "interface_number": 0,
+    "bus_type": 1,
+}
+
+blynclight_plus_template = {
+    "path": b"/BOGUS/PATH",
+    "serial_number": "",
+    "release_number": 256,
+    "manufacturer_string": "",
+    "product_string": "Blynclight Plus",
+    "usage_page": 65280,
+    "usage": 1,
+    "interface_number": 0,
+    "bus_type": 1,
+}
+
+
+EMBRAVA_HARDWARE = {
+    Blynclight: make_hardware(Blynclight, blynclight_template),
+    Blynclight_Mini: make_hardware(Blynclight_Mini, blynclight_mini_template),
+    Blynclight_Plus: make_hardware(Blynclight_Plus, blynclight_plus_template),
+}

--- a/tests/vendor_examples/kuando.py
+++ b/tests/vendor_examples/kuando.py
@@ -1,0 +1,35 @@
+"""
+"""
+
+from busylight_core.vendors.kuando import Busylight_Alpha, Busylight_Omega
+
+from .utils import make_hardware
+
+busylight_alpha_template = {
+    "path": b"/BOGUS/PATH",
+    "serial_number": "",
+    "release_number": 256,
+    "manufacturer_string": "PLENOM APS",
+    "product_string": "BUSYLIGHT ALPHA",
+    "usage_page": 65280,
+    "usage": 1,
+    "interface_number": 0,
+    "bus_type": 1,
+}
+
+busylight_omega_template = {
+    "path": b"/BOGUS/PATH",
+    "serial_number": "",
+    "release_number": 256,
+    "manufacturer_string": "PLENOM APS",
+    "product_string": "BUSYLIGHT OMEGA",
+    "usage_page": 65280,
+    "usage": 1,
+    "interface_number": 0,
+    "bus_type": 1,
+}
+
+KUANDO_HARDWARE = {
+    Busylight_Alpha: make_hardware(Busylight_Alpha, busylight_alpha_template),
+    Busylight_Omega: make_hardware(Busylight_Omega, busylight_omega_template),
+}

--- a/tests/vendor_examples/luxafor.py
+++ b/tests/vendor_examples/luxafor.py
@@ -1,0 +1,64 @@
+"""
+"""
+
+from busylight_core.vendors.luxafor import Bluetooth, Flag, Mute, Orb
+
+from .utils import make_hardware
+
+bluetooth_template = {
+    "path": b"/BOGUS/PATH",
+    "serial_number": "",
+    "release_number": 256,
+    "manufacturer_string": "",
+    "product_string": "LUXAFOR BT",
+    "usage_page": 65280,
+    "usage": 1,
+    "interface_number": 0,
+    "bus_type": 1,
+}
+
+
+flag_template = {
+    "path": b"/BOGUS/PATH",
+    "serial_number": "",
+    "release_number": 256,
+    "manufacturer_string": "",
+    "product_string": "LUXAFOR FLAG",
+    "usage_page": 65280,
+    "usage": 1,
+    "interface_number": 0,
+    "bus_type": 1,
+}
+
+
+mute_template = {
+    "path": b"/BOGUS/PATH",
+    "serial_number": "",
+    "release_number": 256,
+    "manufacturer_string": "",
+    "product_string": "LUXAFOR MUTE",
+    "usage_page": 65280,
+    "usage": 1,
+    "interface_number": 0,
+    "bus_type": 1,
+}
+
+
+orb_template = {
+    "path": b"/BOGUS/PATH",
+    "serial_number": "",
+    "release_number": 256,
+    "manufacturer_string": "",
+    "product_string": "LUXAFOR ORB",
+    "usage_page": 65280,
+    "usage": 1,
+    "interface_number": 0,
+    "bus_type": 1,
+}
+
+LUXAFOR_HARDWARE = {
+    Bluetooth: make_hardware(Bluetooth, bluetooth_template),
+    Flag: make_hardware(Flag, flag_template),
+    Mute: make_hardware(Mute, mute_template),
+    Orb: make_hardware(Orb, orb_template),
+}

--- a/tests/vendor_examples/muteme.py
+++ b/tests/vendor_examples/muteme.py
@@ -1,0 +1,35 @@
+"""
+"""
+
+from busylight_core.vendors.muteme import MuteMe, MuteMe_Mini
+
+from .utils import make_hardware
+
+muteme_template = {
+    "path": b"/BOGUS/PATH",
+    "serial_number": "",
+    "release_number": 256,
+    "manufacturer_string": "muteme.com",
+    "product_string": "MuteMe",
+    "usage_page": 9,
+    "usage": 6,
+    "interface_number": 0,
+    "bus_type": 1,
+}
+muteme_mini_template = {
+    "path": b"/BOGUS/PATH",
+    "serial_number": "",
+    "release_number": 256,
+    "manufacturer_string": "muteme.com",
+    "product_string": "MuteMe Mini",
+    "usage_page": 9,
+    "usage": 6,
+    "interface_number": 0,
+    "bus_type": 1,
+}
+
+
+MUTEME_HARDWARE = {
+    MuteMe: make_hardware(MuteMe, muteme_template),
+    MuteMe_Mini: make_hardware(MuteMe_Mini, muteme_mini_template),
+}

--- a/tests/vendor_examples/mutesync.py
+++ b/tests/vendor_examples/mutesync.py
@@ -1,0 +1,21 @@
+"""
+"""
+
+from busylight_core.hardware import ConnectionType
+from busylight_core.vendors.mutesync import MuteSync
+
+from .utils import make_hardware
+
+mutesync_template = {
+    "device_type": ConnectionType.SERIAL,
+    "path": b"/BOGUS/PATH",
+    "serial_number": "S7GWBRO3JUH8AF",
+    "manufacturer_string": "commutesync",
+    "product_string": "MuteSync Button",
+    "bus_type": 1,
+}
+
+
+MUTESYNC_HARDWARE = {
+    MuteSync: make_hardware(MuteSync, mutesync_template),
+}

--- a/tests/vendor_examples/plantronics.py
+++ b/tests/vendor_examples/plantronics.py
@@ -1,0 +1,22 @@
+"""
+"""
+
+from busylight_core.vendors.plantronics import Status_Indicator
+
+from .utils import make_hardware
+
+status_indicator_template = {
+    "path": b"/BOGUS/PATH",
+    "serial_number": "",
+    "release_number": 1,
+    "manufacturer_string": "",
+    "product_string": "Plantronics Status Indicator",
+    "usage_page": 65280,
+    "usage": 1,
+    "interface_number": 0,
+    "bus_type": 1,
+}
+
+PLANTRONICS_HARDWARE = {
+    Status_Indicator: make_hardware(Status_Indicator, status_indicator_template),
+}

--- a/tests/vendor_examples/thingm.py
+++ b/tests/vendor_examples/thingm.py
@@ -1,0 +1,23 @@
+"""
+"""
+
+from busylight_core.vendors.thingm import Blink1
+
+from .utils import make_hardware
+
+blink1_template = {
+    "path": b"/BOGUS/PATH",
+    "serial_number": "3684ee30",
+    "release_number": 257,
+    "manufacturer_string": "ThingM",
+    "product_string": "blink(1) mk3",
+    "usage_page": 65451,
+    "usage": 8192,
+    "interface_number": 0,
+    "bus_type": 1,
+}
+
+
+THINGM_HARDWARE = {
+    Blink1: make_hardware(Blink1, blink1_template),
+}

--- a/tests/vendor_examples/utils.py
+++ b/tests/vendor_examples/utils.py
@@ -1,0 +1,18 @@
+"""
+"""
+
+from busylight_core import Light
+from busylight_core.hardware import ConnectionType, Hardware
+
+
+def make_hardware(
+    subclass: Light,
+    template: dict[str, str | bytes | int],
+) -> list[Hardware]:
+
+    for (v, p), name in subclass.supported_device_ids().items():
+        match template.get("device_type", ConnectionType.HID):
+            case ConnectionType.HID:
+                yield Hardware.from_hid({**template, "vendor_id": v, "product_id": p})
+            case ConnectionType.SERIAL:
+                yield Hardware(**{**template, "vendor_id": v, "product_id": p})

--- a/uv.lock
+++ b/uv.lock
@@ -99,6 +99,8 @@ dev = [
     { name = "poethepoet", version = "0.36.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.9'" },
     { name = "pytest", version = "8.3.5", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.9'" },
     { name = "pytest", version = "8.4.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.9'" },
+    { name = "pytest-asyncio", version = "0.24.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.9'" },
+    { name = "pytest-asyncio", version = "1.0.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.9'" },
     { name = "pytest-cov", version = "5.0.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.9'" },
     { name = "pytest-cov", version = "6.2.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.9'" },
     { name = "ruff" },
@@ -132,6 +134,7 @@ dev = [
     { name = "mypy" },
     { name = "poethepoet" },
     { name = "pytest" },
+    { name = "pytest-asyncio" },
     { name = "pytest-cov" },
     { name = "ruff" },
     { name = "ty" },
@@ -1751,6 +1754,38 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/08/ba/45911d754e8eba3d5a841a5ce61a65a685ff1798421ac054f85aa8747dfb/pytest-8.4.1.tar.gz", hash = "sha256:7c67fd69174877359ed9371ec3af8a3d2b04741818c51e5e99cc1742251fa93c", size = 1517714, upload-time = "2025-06-18T05:48:06.109Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/29/16/c8a903f4c4dffe7a12843191437d7cd8e32751d5de349d45d3fe69544e87/pytest-8.4.1-py3-none-any.whl", hash = "sha256:539c70ba6fcead8e78eebbf1115e8b589e7565830d7d006a8723f19ac8a0afb7", size = 365474, upload-time = "2025-06-18T05:48:03.955Z" },
+]
+
+[[package]]
+name = "pytest-asyncio"
+version = "0.24.0"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version < '3.9'",
+]
+dependencies = [
+    { name = "pytest", version = "8.3.5", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.9'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/52/6d/c6cf50ce320cf8611df7a1254d86233b3df7cc07f9b5f5cbcb82e08aa534/pytest_asyncio-0.24.0.tar.gz", hash = "sha256:d081d828e576d85f875399194281e92bf8a68d60d72d1a2faf2feddb6c46b276", size = 49855, upload-time = "2024-08-22T08:03:18.145Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/96/31/6607dab48616902f76885dfcf62c08d929796fc3b2d2318faf9fd54dbed9/pytest_asyncio-0.24.0-py3-none-any.whl", hash = "sha256:a811296ed596b69bf0b6f3dc40f83bcaf341b155a269052d82efa2b25ac7037b", size = 18024, upload-time = "2024-08-22T08:03:15.536Z" },
+]
+
+[[package]]
+name = "pytest-asyncio"
+version = "1.0.0"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.10'",
+    "python_full_version == '3.9.*'",
+]
+dependencies = [
+    { name = "pytest", version = "8.4.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.9'" },
+    { name = "typing-extensions", version = "4.14.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.9.*'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d0/d4/14f53324cb1a6381bef29d698987625d80052bb33932d8e7cbf9b337b17c/pytest_asyncio-1.0.0.tar.gz", hash = "sha256:d15463d13f4456e1ead2594520216b225a16f781e144f8fdf6c5bb4667c48b3f", size = 46960, upload-time = "2025-05-26T04:54:40.484Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/30/05/ce271016e351fddc8399e546f6e23761967ee09c8c568bbfbecb0c150171/pytest_asyncio-1.0.0-py3-none-any.whl", hash = "sha256:4f024da9f1ef945e680dc68610b52550e36590a67fd31bb3b4943979a1f90ef3", size = 15976, upload-time = "2025-05-26T04:54:39.035Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -83,9 +83,11 @@ name = "busylight-core"
 version = "0.1.0"
 source = { editable = "." }
 dependencies = [
+    { name = "hidapi" },
     { name = "loguru" },
     { name = "pydantic-settings", version = "2.8.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.9'" },
     { name = "pydantic-settings", version = "2.10.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.9'" },
+    { name = "pyserial" },
     { name = "typer" },
 ]
 
@@ -118,8 +120,10 @@ docs = [
 
 [package.metadata]
 requires-dist = [
+    { name = "hidapi", specifier = ">=0.14.0.post4" },
     { name = "loguru" },
     { name = "pydantic-settings" },
+    { name = "pyserial", specifier = ">=3.5" },
     { name = "typer" },
 ]
 
@@ -506,6 +510,78 @@ wheels = [
 ]
 
 [[package]]
+name = "hidapi"
+version = "0.14.0.post4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "setuptools", version = "75.3.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.9'" },
+    { name = "setuptools", version = "80.9.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.9'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/47/72/21ccaaca6ffb06f544afd16191425025d831c2a6d318635e9c8854070f2d/hidapi-0.14.0.post4.tar.gz", hash = "sha256:48fce253e526d17b663fbf9989c71c7ef7653ced5f4be65f1437c313fb3dbdf6", size = 174388, upload-time = "2024-11-19T16:38:10.316Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d8/30/fb21c7ec91045c9bc4b4e8c6aeb99d59c040380618e50f0142ffde459490/hidapi-0.14.0.post4-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:01747e681d138ec614321ef6f069e5be3743fa210112e529a34d3e99635e4ac0", size = 70384, upload-time = "2024-11-19T16:35:51.274Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/c4/8bd7e052d5bcca3c535e341e4154237ec452ef943bb4373b01ec9b29ec71/hidapi-0.14.0.post4-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:8e20d0a1298a4bd342d7d927d928f1a5a29e5fc9dbf9a79e95dc6e2d386d5070", size = 68114, upload-time = "2024-11-19T16:35:53.435Z" },
+    { url = "https://files.pythonhosted.org/packages/70/ad/c882d4c37173590010577322802b9cbbe968080e36e6e619b1b895270d10/hidapi-0.14.0.post4-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f0cc21e82e95cb92ef951df8eb8acf5626ac8fa14ab5292abdab1b2349970445", size = 1026316, upload-time = "2024-11-19T16:35:55.596Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/8e/b39cdece9b5bc75599646cd997fdc5cbe0ed7582729b62f41e543157f907/hidapi-0.14.0.post4-cp310-cp310-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:cb1a2b5da0dcfab6837281342d1785cc373484bd3f27bd06fd2211d88075a7bd", size = 1026477, upload-time = "2024-11-19T16:35:58.158Z" },
+    { url = "https://files.pythonhosted.org/packages/87/b9/aa613d155250fbfe1d5500f724014b910747424e7bd3fa039858addc7e0d/hidapi-0.14.0.post4-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:e11d475429a1bc943ceac4ad8da4be63b240e00da5e10863fc3cbd9a35fdb51c", size = 1018595, upload-time = "2024-11-19T16:36:00.467Z" },
+    { url = "https://files.pythonhosted.org/packages/db/d4/3a07df2acbbadd133d5c4064d296c2ac1703b72cbaa28c78685fd93ea18a/hidapi-0.14.0.post4-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:2d1c102f754b2085b270e7c29cb8a148ffb05e10325c373d05ac16e2cbce131c", size = 634502, upload-time = "2024-11-19T16:36:02.259Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/23/c8b55b71ca3306fa83735ef04129e6a68648c736f29280ef0ab6b8b34f0a/hidapi-0.14.0.post4-cp310-cp310-musllinux_1_2_i686.whl", hash = "sha256:7d099c259aadcab2bc3f4fb5a1db579ec886c2cade7533016f62778235150746", size = 623671, upload-time = "2024-11-19T16:36:04.774Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/47/e88e409dec1f9539dfdad7a9bc95c3dfe781176b3eeaba56006cd90d19bf/hidapi-0.14.0.post4-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:80fa94668d21b12daf62b034f647d71236470a8ba9a7580e220c47e9c119d932", size = 647046, upload-time = "2024-11-19T16:36:06.91Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/3f/6b935841fc49e43df51422bda68be506407330c498a05eab8ea23908c932/hidapi-0.14.0.post4-cp310-cp310-win32.whl", hash = "sha256:21ebd1420db116733536fae227f1cb30ad74bded5090269cdda4facfa73a8867", size = 63056, upload-time = "2024-11-19T16:36:08.869Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/2b/ca6f1590f5eb6520124518141f9d759eb0744d5a3e622b4bb9c9044640e8/hidapi-0.14.0.post4-cp310-cp310-win_amd64.whl", hash = "sha256:a90cfdd29c10425cd4e4cff34adb12d25048561fc946f3562679e45721060a1c", size = 70327, upload-time = "2024-11-19T16:36:10.005Z" },
+    { url = "https://files.pythonhosted.org/packages/59/b2/6666dfae3c48986a3cf77d049ff8bc6e6620ac0402443ef235b82684eeea/hidapi-0.14.0.post4-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:74ae8ce339655b2568d74e49c8ef644d34a445dd0a9b4b89d1bf09447b83f5af", size = 71068, upload-time = "2024-11-19T16:36:11.123Z" },
+    { url = "https://files.pythonhosted.org/packages/35/ad/5c3dfcb986de80f3ea61908bb2c7ff498900ee79df59a894d834e49b55c9/hidapi-0.14.0.post4-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:e749b79d9cafc1e9fd9d397d8039377c928ca10a36847fda6407169513802f68", size = 68750, upload-time = "2024-11-19T16:36:12.902Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/ab/94ff5dc6c66227bbf316cf8b056145922d1ca931a37092519e8247214df7/hidapi-0.14.0.post4-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:4169893fe5e368777fce7575a8bdedc1861f13d8fb9fda6b05e8155dde6eb7f1", size = 1072450, upload-time = "2024-11-19T16:36:15.306Z" },
+    { url = "https://files.pythonhosted.org/packages/11/77/1e8c35728a17baae2c61646d7060062249f1f01ecd2c28631d07aa8547af/hidapi-0.14.0.post4-cp311-cp311-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:0d51f8102a2441ce22e080576f8f370d25cb3962161818a89f236b0401840f18", size = 1067973, upload-time = "2024-11-19T16:36:16.932Z" },
+    { url = "https://files.pythonhosted.org/packages/99/82/540a15251d27287742a4c9f897bed01ccc82ab2ea6e4321ed3468741dd33/hidapi-0.14.0.post4-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ff021ed0962f2d5d67405ae53c85f6cb3ab8c5af3dff7db8c74672f79f7a39d1", size = 1064054, upload-time = "2024-11-19T16:36:19.53Z" },
+    { url = "https://files.pythonhosted.org/packages/72/93/bb8ed59a06faa0262068486f3f01b49c68e0ae055940f5c9c65bb97064c7/hidapi-0.14.0.post4-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:d8ab5ba9fce95e342335ef48640221a46600c1afb66847432fad9823d40a2022", size = 682621, upload-time = "2024-11-19T16:36:21.214Z" },
+    { url = "https://files.pythonhosted.org/packages/53/42/e262091785d25b30fcfeb0c87b8e0b96ba935336181bab86e7ee25181dd1/hidapi-0.14.0.post4-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:56d7538a4e156041bb80f07f47c327f8944e39da469b010041ce44e324d0657c", size = 669789, upload-time = "2024-11-19T16:36:22.725Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/eb/b0516fadd686ad5b3d99df0db4e16d4d93ae5f74506ac0b2cf4452733e49/hidapi-0.14.0.post4-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:a28de4a03fc276614518d8d0997d8152d0edaf8ca9166522316ef1c455e8bc29", size = 696581, upload-time = "2024-11-19T16:36:25.283Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/b5/35f053d1268c61e1ce6999059d416118d11fd60ba496a3e29c9adcf2ecd7/hidapi-0.14.0.post4-cp311-cp311-win32.whl", hash = "sha256:348e68e3a2145a6ec6bebce13ffdf3e5883d8c720752c365027f16e16764def6", size = 62950, upload-time = "2024-11-19T16:36:26.496Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/e9/d91652ad32f4266c832f8b09879ac1cad9ad5b1660ef35d9ea7171a9e39b/hidapi-0.14.0.post4-cp311-cp311-win_amd64.whl", hash = "sha256:5a5af70dad759b45536a9946d8232ef7d90859845d3554c93bea3e790250df75", size = 70396, upload-time = "2024-11-19T16:36:27.63Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/9a/9b7d5d5e2c003aed2fecdc348caff8d3b6a8ead0220da489ccb822d7e5ef/hidapi-0.14.0.post4-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:129d684c2760fafee9014ce63a58d8e2699cdf00cd1a11bb3d706d4715f5ff96", size = 71668, upload-time = "2024-11-19T16:36:28.666Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/e5/a919eb542a692cc27dc58b1997dd860cace0e4c64e38c8bf9236ff8b95b7/hidapi-0.14.0.post4-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:4f04de00e40db2efc0bcdd047c160274ba7ccd861100fd87c295dd63cb932f2f", size = 69146, upload-time = "2024-11-19T16:36:30.484Z" },
+    { url = "https://files.pythonhosted.org/packages/37/7c/63316c8cba89cc039a952bb8805c3fb585e79f7fc8a5d27acaa6beb2fe81/hidapi-0.14.0.post4-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:10a01af155c51a8089fe44e627af2fbd323cfbef7bd55a86837d971aef6088b0", size = 1083772, upload-time = "2024-11-19T16:36:32.798Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/a8/bb222e3f096467d8e37c717000b9b0c6acee043c1145eaaeba4abfc8cffd/hidapi-0.14.0.post4-cp312-cp312-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:6eaff1d120c47e1a121eada8dc85eac007d1ed81f3db7fc0da5b6ed17d8edefb", size = 1081215, upload-time = "2024-11-19T16:36:35.512Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/c8/52134f7d3e09fd4feb7756ccd872c55bfd1899ee81ceed4f8ad5ae39f457/hidapi-0.14.0.post4-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:fedb9c3be6a2376de436d13fcb37a686a9b6bc988585bcc4f5ec61cad925e794", size = 1077222, upload-time = "2024-11-19T16:36:38.062Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/da/88ebbd465dbaff04e9ef3bbdb4a6ca9d24a3458e4726878dbe26bb69236e/hidapi-0.14.0.post4-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:6270677da02e86b56b81afd5f6f313736b8315b493f3c8a431da285e3a3c5de9", size = 694510, upload-time = "2024-11-19T16:36:39.572Z" },
+    { url = "https://files.pythonhosted.org/packages/da/f0/ea437ed339c5f0b446983011000d8cad8c4f8a51ee39e837d16e101b66da/hidapi-0.14.0.post4-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:da700db947562f8c0ac530215b74b5a27e4c669916ec99cfb5accd14ba08562c", size = 682635, upload-time = "2024-11-19T16:36:41.35Z" },
+    { url = "https://files.pythonhosted.org/packages/01/e9/14e63f1a5ec0c2430b84695d28e994b2b63398544adb20d910f6dc41ac66/hidapi-0.14.0.post4-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:707b1ebf5cb051b020e94b039e603351bf2e6620b48fc970228e0dd5d3a91fca", size = 701667, upload-time = "2024-11-19T16:36:43.135Z" },
+    { url = "https://files.pythonhosted.org/packages/df/3d/8a37ed1b250ae45eb7fa5cd3227c865d38a1ddf9ccab626f4f6adfbd424a/hidapi-0.14.0.post4-cp312-cp312-win32.whl", hash = "sha256:1487312ad50cf2c08a5ea786167b3229afd6478c4b26974157c3845a84e91231", size = 63123, upload-time = "2024-11-19T16:36:44.329Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/fd/e642211e579875e35015aed12d3b2c2a25f6a731ff846a2c2aaaf4bf8898/hidapi-0.14.0.post4-cp312-cp312-win_amd64.whl", hash = "sha256:8d924bd002a1c17ca51905b3b7b3d580e80ec211a9b8fe4667b73db0ff9e9b54", size = 70478, upload-time = "2024-11-19T16:36:45.388Z" },
+    { url = "https://files.pythonhosted.org/packages/38/c7/8601f03a6eeeac35655245177b50bb00e707f3392e0a79c34637f8525207/hidapi-0.14.0.post4-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:6f96ae777e906f0a9d6f75e873313145dfec2b774f558bfcae8ba34f09792460", size = 70358, upload-time = "2024-11-19T16:36:46.405Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/5d/7376cf339fbe6fca26048e3c7e183ef4d99c046cc5d8378516a745914327/hidapi-0.14.0.post4-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:6439fc9686518d0336fac8c5e370093279f53c997540065fce131c97567118d8", size = 68034, upload-time = "2024-11-19T16:36:47.419Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/5a/4bca20898c699810f016d2719b980fc57fe36d5012d03eca7a89ace98547/hidapi-0.14.0.post4-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:2acadb4f1ae569c4f73ddb461af8733e8f5efcb290c3d0ef1b0671ba793b0ae3", size = 1075570, upload-time = "2024-11-19T16:36:48.931Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/c6/66e6b7c27297249bc737115dff4a1e819d3e0e73885160a3104ebec7ac13/hidapi-0.14.0.post4-cp313-cp313-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:884fa003d899113e14908bd3b519c60b48fc3cec0410264dcbdad1c4a8fc2e8d", size = 1081482, upload-time = "2024-11-19T16:36:51.021Z" },
+    { url = "https://files.pythonhosted.org/packages/86/a8/21e9860eddeefd0dc41b3f7e6e81cd9ff53c2b07130f57776b56a1dddc66/hidapi-0.14.0.post4-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:8a2d466b995f8ff387d68c052d3b74ee981a4ddc4f1a99f32f2dc7022273dc11", size = 1069549, upload-time = "2024-11-19T16:36:52.808Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/01/3adf46a7ea5bf31f12e09d4392e1810e662101ba6611214ea6e2c35bea7a/hidapi-0.14.0.post4-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:e1f6409854c0a8ed4d1fdbe88d5ee4baf6f19996d1561f76889a132cb083574d", size = 698200, upload-time = "2024-11-19T16:36:54.606Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/19/db15cd21bef1b0dc8ef4309c5734b64affb7e88540efd3c090f153cdae0b/hidapi-0.14.0.post4-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:bca568a2b7d0d454c7921d70b1cc44f427eb6f95961b6d7b3b9b4532d0de74ef", size = 671554, upload-time = "2024-11-19T16:36:56.2Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/23/f896ee8f0977710c354bd1b9ac6d5206c12842bd39d78a357c866f8ec6b6/hidapi-0.14.0.post4-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:9f14ac2737fd6f58d88d2e6bf8ebd03aac7b486c14d3f570b7b1d0013d61b726", size = 703897, upload-time = "2024-11-19T16:36:57.796Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/5e/3c93bb12b01392b538870bc710786fee86a9ced074a8b5c091a59786ee07/hidapi-0.14.0.post4-cp313-cp313-win32.whl", hash = "sha256:b6b9c4dbf7d7e2635ff129ce6ea82174865c073b75888b8b97dda5a3d9a70493", size = 62688, upload-time = "2024-11-19T16:36:59.124Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/a6/0d43ac0be00db25fb0c2c6125e15a3e3536196c9a7cd806d50ebfb37b375/hidapi-0.14.0.post4-cp313-cp313-win_amd64.whl", hash = "sha256:87218eeba366c871adcc273407aacbabab781d6a964919712d5583eded5ca50f", size = 69749, upload-time = "2024-11-19T16:37:00.561Z" },
+    { url = "https://files.pythonhosted.org/packages/73/af/0b9e5866a7c606a964bdb37f13a8ce302a37e0f3b3687ddb0129eb9bc2d8/hidapi-0.14.0.post4-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:9e4b462fc1f2b160442618448132aebadb71c06b6eb7654eae4385c490100a67", size = 71386, upload-time = "2024-11-19T16:37:33.255Z" },
+    { url = "https://files.pythonhosted.org/packages/18/eb/77f70acbf6490662948617ca18ac1385339f15ae41470d153576a48b9678/hidapi-0.14.0.post4-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:68d7e9ba5c48e50f322057b9f88d799c105b5d46c966981aa8e5047b6091541f", size = 68923, upload-time = "2024-11-19T16:37:34.986Z" },
+    { url = "https://files.pythonhosted.org/packages/75/8b/50ae9117b9b31ae47a444a80449f018c6ca41496f41427d3e926d9ec610e/hidapi-0.14.0.post4-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:293b207e737df4577d27661c5135e7c16976f706d3739d7a53a169dde1aaebaa", size = 1028806, upload-time = "2024-11-19T16:37:36.803Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/58/dac1d9da608859a91e847af078f8a19d1d7fa0e102042317e175bf4aff04/hidapi-0.14.0.post4-cp38-cp38-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:a18af6ebd751eea7ddfb093ddf7d0371b05ba0f9a2f8593c7255a34e6bd753ff", size = 1029763, upload-time = "2024-11-19T16:37:39.371Z" },
+    { url = "https://files.pythonhosted.org/packages/76/d5/5b72ad4a48c685dcddc9b3d5ce7bf7c9042b1e49edbf520243d71fc0bd1a/hidapi-0.14.0.post4-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:380a74e743afe7a0241e0efce73ce9697f41d4e2e0a030be5458a44f9119427a", size = 1023448, upload-time = "2024-11-19T16:37:41.345Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/19/cc8fb49c9ccd77359fc965e6a68aa1b8fc40d9310a73ca1b053cbed121bb/hidapi-0.14.0.post4-cp38-cp38-musllinux_1_2_aarch64.whl", hash = "sha256:6e08884ee9e1e3963701c1cdf22edd17c7ff708728f163efc396964460b3f9b4", size = 645900, upload-time = "2024-11-19T16:37:42.97Z" },
+    { url = "https://files.pythonhosted.org/packages/36/2c/ad571dc9413d5a518fd7734144a1e88a6902b79af5a0e0221737a067a9dd/hidapi-0.14.0.post4-cp38-cp38-musllinux_1_2_i686.whl", hash = "sha256:fbd2835ff193d0261e0de375fea006cb7cb18a30ae1657af48a43e381f6a0995", size = 633659, upload-time = "2024-11-19T16:37:44.469Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/a0/befd611d701af4c1fd4b591b5ef73042dba6383e971620878e11815cc9bd/hidapi-0.14.0.post4-cp38-cp38-musllinux_1_2_x86_64.whl", hash = "sha256:6b424ec16068d58d13fb67c7fb728824a3888f8f7fb6ffa3c82d5a54d8b74b7f", size = 656107, upload-time = "2024-11-19T16:37:46.104Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/73/d5bcd849b9e21518519c630a55bccc3dba0aca3c4de31a3147147513a753/hidapi-0.14.0.post4-cp38-cp38-win32.whl", hash = "sha256:8de94caca7f2616e41466c0ccdf7a96f567914e9e85e89e0b607018777fc0755", size = 63732, upload-time = "2024-11-19T16:37:47.481Z" },
+    { url = "https://files.pythonhosted.org/packages/77/c5/56a8909235e1c53991beca2debee4c39c13cd4219e8005a7ca10110f80b0/hidapi-0.14.0.post4-cp38-cp38-win_amd64.whl", hash = "sha256:1591e98c0e6db4cc1e34e96295b4ea68eaf37d365d664570441388869e8e3618", size = 71065, upload-time = "2024-11-19T16:37:48.71Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/3d/c81b57a89591e041f83d3e8b0238816628c6dd4d278adfc1e1754285c8da/hidapi-0.14.0.post4-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:58a0a0c029886de8b301ce1ee2e7fd6914ae1ca49feb37cc9930c26baa683427", size = 71026, upload-time = "2024-11-19T16:37:50.268Z" },
+    { url = "https://files.pythonhosted.org/packages/86/a9/53d824f6e7bab48851797824ede894f34604501b4293ea18ff1816837631/hidapi-0.14.0.post4-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:e70eab52781e58e819730d99e3c825e92c15ec2138b6902ed078c8cd73317ce0", size = 68705, upload-time = "2024-11-19T16:37:52.102Z" },
+    { url = "https://files.pythonhosted.org/packages/32/5a/15833a49e121f02e9527cfc07506766f41e3d3c2f1259510ffca29fc4493/hidapi-0.14.0.post4-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:97192b7756dd854cb2ebc8a1862ffa009cdc203e0399777764462cae3c459d58", size = 1033872, upload-time = "2024-11-19T16:37:54.56Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/18/d7904ee0ed21b0c9ee11847bba49cd0e4fb33f63b44eddd78a60c35d6e08/hidapi-0.14.0.post4-cp39-cp39-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:f27c74deda0282a97dd0f006fd79d6d08fdb16c7a3ba156d52fce85e48515b0a", size = 1032703, upload-time = "2024-11-19T16:37:56.757Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/d8/6dafae64a041eb80c63be77ba2bc57c08ac1f44fb6579046bd6b123d94ef/hidapi-0.14.0.post4-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c8f722864a03c1d243a9538f0872e233d07fc3fe1d945c66c0cb632060d6d009", size = 1024884, upload-time = "2024-11-19T16:37:58.712Z" },
+    { url = "https://files.pythonhosted.org/packages/97/67/c3e33dee7cfe899ab8eb38669e2d7263e2444e03585427c3f42dedcc0b7a/hidapi-0.14.0.post4-cp39-cp39-musllinux_1_2_aarch64.whl", hash = "sha256:f67e60eaa287e0fa35223f2d1f9afda81dd7312c7ba07e08fbdaf1af8a923530", size = 640660, upload-time = "2024-11-19T16:38:00.918Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/40/ab4f320c22d5b164e0fad6f8193d01efede3d56c62f8778ab9a0d9304b5b/hidapi-0.14.0.post4-cp39-cp39-musllinux_1_2_i686.whl", hash = "sha256:fa66391be8acb358b381c30f32be5880d591a3358e531d980832d593dfe83d5a", size = 629637, upload-time = "2024-11-19T16:38:03.316Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/4f/2867e593edadf6b8b9534da4417b2f9b61974d794b553ea8561dcc93e9df/hidapi-0.14.0.post4-cp39-cp39-musllinux_1_2_x86_64.whl", hash = "sha256:f3ce310d366335e1ac9416d8e4a27d6eef2ae896fbee0135484d39d001711bea", size = 651274, upload-time = "2024-11-19T16:38:05.676Z" },
+    { url = "https://files.pythonhosted.org/packages/99/5a/237674ac9dcca1254157522619150f46eabc9327190c08567f5bd24ec119/hidapi-0.14.0.post4-cp39-cp39-win32.whl", hash = "sha256:60115947607b8b0a719420726a541bad68728ece38b20654e81fef77c9e0bd2f", size = 63640, upload-time = "2024-11-19T16:38:07.251Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/cf/d48f6b604546f8df09214481ccc3b3526fa8ed6ab5e2ac5daacba3ea4aff/hidapi-0.14.0.post4-cp39-cp39-win_amd64.whl", hash = "sha256:21627bb8a0e2023da1dfb7cb7b970c30d6a86e6498721f1123d018b2f64b426f", size = 70849, upload-time = "2024-11-19T16:38:08.326Z" },
+]
+
+[[package]]
 name = "idna"
 version = "3.10"
 source = { registry = "https://pypi.org/simple" }
@@ -537,7 +613,7 @@ resolution-markers = [
     "python_full_version == '3.9.*'",
 ]
 dependencies = [
-    { name = "zipp", version = "3.23.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.9'" },
+    { name = "zipp", version = "3.23.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.9.*'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/76/66/650a33bd90f786193e4de4b3ad86ea60b53c89b669a5c7be931fac31cdb0/importlib_metadata-8.7.0.tar.gz", hash = "sha256:d13b81ad223b890aa16c5471f2ac3056cf76c5f10f82d6f9292f0b415f389000", size = 56641, upload-time = "2025-04-27T15:29:01.736Z" }
 wheels = [
@@ -1627,6 +1703,15 @@ wheels = [
 ]
 
 [[package]]
+name = "pyserial"
+version = "3.5"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/1e/7d/ae3f0a63f41e4d2f6cb66a5b57197850f919f59e558159a4dd3a818f5082/pyserial-3.5.tar.gz", hash = "sha256:3c77e014170dfffbd816e6ffc205e9842efb10be9f58ec16d3e8675b4925cddb", size = 159125, upload-time = "2020-11-23T03:59:15.045Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/07/bc/587a445451b253b285629263eb51c2d8e9bcea4fc97826266d186f96f558/pyserial-3.5-py2.py3-none-any.whl", hash = "sha256:c4451db6ba391ca6ca299fb3ec7bae67a5c55dde170964c7a14ceefec02f2cf0", size = 90585, upload-time = "2020-11-23T03:59:13.41Z" },
+]
+
+[[package]]
 name = "pytest"
 version = "8.3.5"
 source = { registry = "https://pypi.org/simple" }
@@ -1893,6 +1978,31 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/fe/84/7cc7bd73924ee6be4724be0db5414a4a2ed82d06b30827342315a1be9e9c/ruff-0.12.3-py3-none-win32.whl", hash = "sha256:dfd45e6e926deb6409d0616078a666ebce93e55e07f0fb0228d4b2608b2c248d", size = 10589263, upload-time = "2025-07-11T13:21:07.148Z" },
     { url = "https://files.pythonhosted.org/packages/07/87/c070f5f027bd81f3efee7d14cb4d84067ecf67a3a8efb43aadfc72aa79a6/ruff-0.12.3-py3-none-win_amd64.whl", hash = "sha256:a946cf1e7ba3209bdef039eb97647f1c77f6f540e5845ec9c114d3af8df873e7", size = 11695072, upload-time = "2025-07-11T13:21:11.004Z" },
     { url = "https://files.pythonhosted.org/packages/e0/30/f3eaf6563c637b6e66238ed6535f6775480db973c836336e4122161986fc/ruff-0.12.3-py3-none-win_arm64.whl", hash = "sha256:5f9c7c9c8f84c2d7f27e93674d27136fbf489720251544c4da7fb3d742e011b1", size = 10805855, upload-time = "2025-07-11T13:21:13.547Z" },
+]
+
+[[package]]
+name = "setuptools"
+version = "75.3.2"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version < '3.9'",
+]
+sdist = { url = "https://files.pythonhosted.org/packages/5c/01/771ea46cce201dd42cff043a5eea929d1c030fb3d1c2ee2729d02ca7814c/setuptools-75.3.2.tar.gz", hash = "sha256:3c1383e1038b68556a382c1e8ded8887cd20141b0eb5708a6c8d277de49364f5", size = 1354489, upload-time = "2025-03-12T00:02:19.004Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/15/65/3f0dba35760d902849d39d38c0a72767794b1963227b69a587f8a336d08c/setuptools-75.3.2-py3-none-any.whl", hash = "sha256:90ab613b6583fc02d5369cbca13ea26ea0e182d1df2d943ee9cbe81d4c61add9", size = 1251198, upload-time = "2025-03-12T00:02:17.554Z" },
+]
+
+[[package]]
+name = "setuptools"
+version = "80.9.0"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.10'",
+    "python_full_version == '3.9.*'",
+]
+sdist = { url = "https://files.pythonhosted.org/packages/18/5d/3bf57dcd21979b887f014ea83c24ae194cfcd12b9e0fda66b957c69d1fca/setuptools-80.9.0.tar.gz", hash = "sha256:f36b47402ecde768dbfafc46e8e4207b4360c654f1f3bb84475f0a28628fb19c", size = 1319958, upload-time = "2025-05-27T00:56:51.443Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a3/dc/17031897dae0efacfea57dfd3a82fdd2a2aeb58e0ff71b77b87e44edc772/setuptools-80.9.0-py3-none-any.whl", hash = "sha256:062d34222ad13e0cc312a4c02d73f059e86a4acbfbdea8f8f76b28c99f306922", size = 1201486, upload-time = "2025-05-27T00:56:49.664Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- Fixed 2 failing async tests in `TestTaskableMixinIntegration`
- Resolved deprecation warnings from `asyncio.get_event_loop()` usage
- Added `pytest-asyncio` dependency for proper async test support

## Changes Made
- **Added pytest-asyncio dependency**: Added to `pyproject.toml` dev dependencies to enable `@pytest.mark.asyncio` support
- **Fixed deprecated asyncio usage**: Updated `TaskableMixin.event_loop` to use modern asyncio patterns:
  - Replaced `asyncio.get_event_loop()` with `asyncio.get_running_loop()` + fallback to `asyncio.new_event_loop()`
- **Updated test mocks**: Modified tests in `test_taskable_mixin.py` to mock the new asyncio functions instead of deprecated ones

## Test Results
- **Before**: 2 failing async tests, deprecation warnings
- **After**: All 375 tests passing ✅

## Test plan
- [x] Run `poe test` to verify all tests pass
- [x] Run `poe qc` to ensure code quality checks pass
- [x] Verify async integration tests work correctly
- [x] Confirm no regression in existing functionality

🤖 Generated with [Claude Code](https://claude.ai/code)