### PR TITLE
Fix Embrava device audio capability inheritance

### DIFF
--- a/src/busylight_core/vendors/embrava/blynclight_mini.py
+++ b/src/busylight_core/vendors/embrava/blynclight_mini.py
@@ -2,14 +2,15 @@
 
 from typing import ClassVar
 
-from .embrava_base import EmbravaBase
+from .blynclight_plus import BlynclightPlus
 
 
-class BlynclightMini(EmbravaBase):
+class BlynclightMini(BlynclightPlus):
     """Embrava Blynclight Mini status light controller.
 
-    A smaller version of the Blynclight with the same functionality
-    as the standard Blynclight device.
+    A smaller version of the Blynclight with the similar functionality
+    as the Blynclight Plus device.
+
     """
 
     supported_device_ids: ClassVar[dict[tuple[int, int], str]] = {

--- a/src/busylight_core/vendors/embrava/blynclight_plus.py
+++ b/src/busylight_core/vendors/embrava/blynclight_plus.py
@@ -16,3 +16,32 @@ class BlynclightPlus(EmbravaBase):
         (0x2C0D, 0x0002): "Blynclight Plus",
         (0x2C0D, 0x0010): "Blynclight Plus",
     }
+
+    def play_sound(self, music: int = 0, volume: int = 1, repeat: bool = False) -> None:
+        """Play a sound on the device.
+
+        :param music: Music track number to play (0-7)
+        :param volume: Volume level (0-3)
+        :param repeat: Whether the music repeats
+        """
+        with self.batch_update():
+            self.state.repeat = repeat
+            self.state.play = True
+            self.state.music = music
+            self.state.mute = False
+            self.state.volume = volume
+
+    def stop_sound(self) -> None:
+        """Stop playing any currently playing sound."""
+        with self.batch_update():
+            self.state.play = False
+
+    def mute(self) -> None:
+        """Mute the device sound output."""
+        with self.batch_update():
+            self.state.mute = True
+
+    def unmute(self) -> None:
+        """Unmute the device sound output."""
+        with self.batch_update():
+            self.state.mute = False

--- a/src/busylight_core/vendors/embrava/embrava_base.py
+++ b/src/busylight_core/vendors/embrava/embrava_base.py
@@ -62,35 +62,6 @@ class EmbravaBase(Light):
         with self.batch_update():
             self.state.dim = False
 
-    def play_sound(self, music: int = 0, volume: int = 1, repeat: bool = False) -> None:
-        """Play a sound on the device.
-
-        :param music: Music track number to play (0-7)
-        :param volume: Volume level (0-3)
-        :param repeat: Whether the music repeats
-        """
-        with self.batch_update():
-            self.state.repeat = repeat
-            self.state.play = True
-            self.state.music = music
-            self.state.mute = False
-            self.state.volume = volume
-
-    def stop_sound(self) -> None:
-        """Stop playing any currently playing sound."""
-        with self.batch_update():
-            self.state.play = False
-
-    def mute(self) -> None:
-        """Mute the device sound output."""
-        with self.batch_update():
-            self.state.mute = True
-
-    def unmute(self) -> None:
-        """Unmute the device sound output."""
-        with self.batch_update():
-            self.state.mute = False
-
     def flash(
         self,
         color: tuple[int, int, int],


### PR DESCRIPTION
## Problem
The `EmbravaBase` class incorrectly included audio methods (`play_sound`, `stop_sound`, `mute`, `unmute`) that are not supported by the standard Blynclight device. These audio capabilities are only present in the Plus and Mini variants, but were being exposed on all Embrava devices.

## Root Cause  
The inheritance hierarchy placed audio functionality in the base class, making it available to all Embrava devices regardless of their actual hardware capabilities.

## Solution
This PR corrects the capability distribution across Embrava device variants:

### Changes Made
- **`EmbravaBase`**: Removed audio methods (affects standard Blynclight)
- **`BlynclightPlus`**: Added proper audio capability methods
- **`BlynclightMini`**: Changed to inherit from `BlynclightPlus` instead of `EmbravaBase`

### Inheritance Hierarchy
```
Before: EmbravaBase (with audio) ← Blynclight, BlynclightPlus, BlynclightMini
After:  EmbravaBase (no audio) ← Blynclight
        EmbravaBase ← BlynclightPlus (with audio) ← BlynclightMini  
```

## Impact
✅ **Standard Blynclight**: No longer exposes non-functional audio methods  
✅ **Plus & Mini variants**: Retain full audio functionality  
✅ **API compatibility**: No breaking changes for supported device features  
✅ **Accuracy**: Inheritance now matches actual hardware capabilities

## Testing
- All tests pass without modification
- Code quality checks (ruff) pass  
- No breaking changes to existing functionality

This fix ensures the API accurately represents what each hardware variant can actually do.

🤖 Generated with [Claude Code](https://claude.ai/code)