### PR TITLE
docs: Standardize exception variable names from 'e' to 'error'

### DIFF
--- a/docs/user-guide/cli.md
+++ b/docs/user-guide/cli.md
@@ -281,12 +281,12 @@ try:
     
 except NoLightsFound:
     print("Please connect a busylight device")
-except LightUnavailable as e:
-    print(f"Device unavailable: {e}")
-except LightUnsupported as e:
-    print(f"Device not supported: {e}")
-except InvalidHardwareInfo as e:
-    print(f"Hardware error: {e}")
+except LightUnavailable as error:
+    print(f"Device unavailable: {error}")
+except LightUnsupported as error:
+    print(f"Device not supported: {error}")
+except InvalidHardwareInfo as error:
+    print(f"Hardware error: {error}")
 ```
 
 ### Debug Logging
@@ -404,8 +404,8 @@ def set_all_lights(color, flash=False):
                 light.flash(color, count=2)
             else:
                 light.on(color)
-        except Exception as e:
-            print(f"Failed to control {light.name}: {e}")
+        except Exception as error:
+            print(f"Failed to control {light.name}: {error}")
 
 # Set all lights to green
 set_all_lights((0, 255, 0))

--- a/docs/user-guide/examples.md
+++ b/docs/user-guide/examples.md
@@ -356,10 +356,10 @@ try:
     
 except NoLightsFound:
     print("No busylights found. Please connect a device.")
-except LightUnavailable as e:
-    print(f"Light unavailable: {e}")
-except Exception as e:
-    print(f"Unexpected error: {e}")
+except LightUnavailable as error:
+    print(f"Light unavailable: {error}")
+except Exception as error:
+    print(f"Unexpected error: {error}")
 ```
 
 ### Debugging Device Issues


### PR DESCRIPTION
## Summary
- Standardized exception variable naming in documentation examples
- Changed all instances of `except SomeException as e:` to use `error` instead  
- Ensures consistency with existing codebase which already uses `error` for exception variables
- Updated 6 exception handlers across 2 documentation files

## Files Changed
- **docs/user-guide/cli.md**: Updated 4 exception handlers
  - `LightUnavailable`, `LightUnsupported`, `InvalidHardwareInfo`, and `Exception` handlers
- **docs/user-guide/examples.md**: Updated 2 exception handlers  
  - `LightUnavailable` and `Exception` handlers

## Benefits
- Consistent exception variable naming across documentation and source code
- Better readability with descriptive `error` instead of single letter `e`
- Aligns with established codebase patterns

## Test plan
- [x] All 709 tests pass
- [x] Ruff checks clean  
- [x] Documentation changes only - no functional code changes
- [x] Exception handling examples remain functionally identical

🤖 Generated with [Claude Code](https://claude.ai/code)