### PR TITLE
Update issue templates with correct version commands

### DIFF
--- a/.github/ISSUE_TEMPLATE/1_bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/1_bug_report.yaml
@@ -29,8 +29,8 @@ body:
   - type: input
     attributes:
       label: Version
-      description: What version of busylight_core are you using? (see `busylight_core self version`)
-      placeholder: e.g., busylight_core 0.5.20 (1c17662b3 2025-01-15)
+      description: What version of busylight_core are you using? (see `uv pip list | grep busylight`, `pip list | grep busylight`, or `python -c "import busylight_core; print(busylight_core.version)"`)
+      placeholder: e.g., busylight-core 0.5.20
     validations:
       required: true
 

--- a/.github/ISSUE_TEMPLATE/3_question.yaml
+++ b/.github/ISSUE_TEMPLATE/3_question.yaml
@@ -25,7 +25,7 @@ body:
   - type: input
     attributes:
       label: Version
-      description: What version of busylight_core are you using? (see `busylight_core self version`)
-      placeholder: e.g., busylight_core 0.1.0
+      description: What version of busylight_core are you using? (see `uv pip list | grep busylight`, `pip list | grep busylight`, or `python -c "import busylight_core; print(busylight_core.version)"`)
+      placeholder: e.g., busylight-core 0.1.0
     validations:
       required: false


### PR DESCRIPTION
## Summary

- Replace outdated `busylight_core self version` CLI command with working methods for obtaining version information
- Update bug report and question templates with accurate version retrieval instructions
- Improve issue quality by providing users with commands that actually work

## Changes Made

### Bug Report Template (`1_bug_report.yaml`)
- Updated version description with three working methods for getting version info
- Updated placeholder to show realistic version format (`busylight-core 0.5.20`)

### Question Template (`3_question.yaml`) 
- Updated version description with three working methods for getting version info
- Updated placeholder to show realistic version format (`busylight-core 0.1.0`)

### Feature Request Template (`2_feature_request.yaml`)
- No changes needed (doesn't include version field)

## Version Methods Provided

Users can now obtain version information using any of these methods:

1. **`uv pip list | grep busylight`** - For users with uv package manager
2. **`pip list | grep busylight`** - For standard pip users  
3. **`python -c "import busylight_core; print(busylight_core.version)"`** - Direct Python import method

## Benefits

- **Functional commands**: All provided methods actually work, unlike the previous CLI command
- **Multiple options**: Users can choose the method that matches their setup (uv, pip, or Python)
- **Better issue quality**: Accurate version information leads to more effective bug reports and support
- **Consistent formatting**: Updated placeholders show the actual package name format

## Test Plan

- [x] Verified all three version methods work correctly
- [x] Templates use standard YAML structure and formatting
- [x] Version descriptions are clear and comprehensive
- [x] Placeholders show realistic version format

🤖 Generated with [Claude Code](https://claude.ai/code)