### PR TITLE
fix: refactor Kuando keepalive to instance method and update tests

### DIFF
--- a/src/busylight_core/vendors/kuando/busylight_base.py
+++ b/src/busylight_core/vendors/kuando/busylight_base.py
@@ -16,6 +16,16 @@ class BusylightBase(ColorableMixin, KuandoBase):
     the appropriate strategy (asyncio or threading) based on the calling context.
     """
 
+    # EJO there are two different intervals in play with the Kuando busylight:
+    #     1. refresh interval, how often the keepalive function is called
+    #     2. keepalive interval, how long to wait for a keepalive before ending
+    #        the current operation.
+    #
+    #     If the keepalive is shorter than refresh, the light will perform an
+    #     uncommand flash.
+    REFRESH_INTERVAL = 10
+    KEEPALIVE_INTERVAL = 15
+
     @cached_property
     def state(self) -> State:
         """The device state manager."""
@@ -37,29 +47,20 @@ class BusylightBase(ColorableMixin, KuandoBase):
         with self.batch_update():
             self.state.steps[0].jump(self.color)
 
-        # Environment automatically chooses asyncio or threading!
-        self.add_task("keepalive", _keepalive, interval=10)
+        self.add_task("keepalive", self.keepalive, interval=self.REFRESH_INTERVAL)
 
     def off(self, led: int = 0) -> None:
-        """Turn off the Busylight and stop keepalive.
+        """Turn off the Busylight and cancel keepalive task.
 
         :param led: LED index (unused for Busylight devices)
         """
         self.color = (0, 0, 0)
         with self.batch_update():
             self.state.steps[0].jump(self.color)
+
         self.cancel_task("keepalive")
 
-
-def _keepalive(light: BusylightBase, interval: int = 10) -> None:
-    """Send keepalive packet - works in any context.
-
-    This synchronous function can be called from either asyncio or
-    threading contexts. The TaskableMixin automatically handles
-    the appropriate scheduling strategy.
-
-    :param light: The BusylightBase instance to send keepalive to
-    :param interval: Keepalive interval in seconds (0-15)
-    """
-    with light.batch_update():
-        light.state.steps[0].keep_alive(interval)
+    def keepalive(self, *args, **kwargs) -> None:
+        """Send a keepalive command to the Busylight."""
+        with self.batch_update():
+            self.state.steps[0].keep_alive(self.KEEPALIVE_INTERVAL)

--- a/tests/test_taskable_mixin.py
+++ b/tests/test_taskable_mixin.py
@@ -78,11 +78,11 @@ class TestTaskableMixin:
         mock_loop.create_task.return_value = mock_task
 
         # Mock coroutine function
-        async def mock_coroutine(self) -> str:  # noqa: ARG001
+        async def mock_coroutine(self, *args, **kwargs) -> str:  # noqa: ARG001
             return "test_result"
 
         with patch.object(mixin, "event_loop", mock_loop):
-            result = mixin.add_task("test_task", mock_coroutine)
+            result = mixin.add_task("test_task", mock_coroutine, 0)
 
         # Verify task was created and stored
         mock_loop.create_task.assert_called_once()
@@ -101,7 +101,7 @@ class TestTaskableMixin:
 
         mock_loop = Mock()
         with patch.object(mixin, "event_loop", mock_loop):
-            result = mixin.add_task("existing_task", mock_coroutine)
+            result = mixin.add_task("existing_task", mock_coroutine, 0)
 
         # Should return existing task without creating new one
         assert result is existing_task
@@ -122,7 +122,7 @@ class TestTaskableMixin:
             return "test_result"
 
         with patch.object(mixin, "event_loop", mock_loop):
-            mixin.add_task("test_task", mock_coroutine)
+            mixin.add_task("test_task", mock_coroutine, 0)
 
         # Verify the coroutine was called with self
         mock_loop.create_task.assert_called_once()
@@ -248,7 +248,7 @@ class TestTaskableMixinIntegration:
             return "completed"
 
         # Add a task
-        task = mixin.add_task("real_task", test_coroutine)
+        task = mixin.add_task("real_task", test_coroutine, 0)
 
         # Verify it's a real asyncio task
         assert isinstance(task, asyncio.Task)
@@ -279,8 +279,8 @@ class TestTaskableMixinIntegration:
             return "fast_completed"
 
         # Add multiple tasks
-        slow = mixin.add_task("slow", slow_task)
-        fast = mixin.add_task("fast", fast_task)
+        slow = mixin.add_task("slow", slow_task, 0)
+        fast = mixin.add_task("fast", fast_task, 0)
 
         assert len(mixin.tasks) == 2
 
@@ -334,7 +334,7 @@ class TestTaskableMixinEdgeCases:
 
         # This should raise an error when trying to call None
         with pytest.raises(TypeError):
-            mixin.add_task("bad_task", None)
+            mixin.add_task("bad_task", None, 0)
 
     def test_cancel_task_with_none_in_tasks(self) -> None:
         """Test cancel_task when tasks dict contains None."""


### PR DESCRIPTION
## Summary
- Refactored Kuando BusylightBase to use instance method `keepalive` instead of standalone function `_keepalive`
- Added `REFRESH_INTERVAL` and `KEEPALIVE_INTERVAL` constants for better clarity
- Updated test calls to include required `interval` parameter
- Improved documentation explaining the two different interval concepts

## Changes

### BusylightBase Refactoring
- **Before**: Used standalone `_keepalive` function called via `add_task`
- **After**: Instance method `keepalive` that's part of the class
- Added clear constants for refresh (10s) and keepalive (15s) intervals
- Enhanced documentation explaining why these intervals differ

### Test Updates
- Updated `test_taskable_mixin.py` calls to include `interval=0` parameter
- Ensures compatibility with the unified `add_task` signature

## Benefits
- **Better encapsulation**: Keepalive behavior is now part of the class
- **Clearer constants**: Named intervals instead of magic numbers
- **Improved docs**: Explanation of interval relationship and uncommanded flash prevention
- **Consistent API**: All tests use the same `add_task` signature

## Test Results
✅ All tests pass with the refactored implementation

🤖 Generated with [Claude Code](https://claude.ai/code)