### PR TITLE
Add support for early Blynclight models (VID 0x1130)

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ looking for a command-line interface to control your lights? Check out
 | **Agile Innovative** | BlinkStick, BlinkStick Pro, BlinkStick Flex, BlickStick Nano, BlinkStick Strip, BlinkStick Square |
 | **CompuLab** | fit-statUSB |
 | **EPOS** | Busylight |
-| **Embrava** | Blynclight, Blynclight Mini, Blynclight Plus |
+| **Embrava** | Blynclight, Blynclight Mini, Blynclight Plus, Blynclight BLYNCUSB20 |
 | **Kuando** | Busylight Alpha, Busylight Omega |
 | **Luxafor** | Flag, Mute, Orb, Bluetooth |
 | **MuteMe** | MuteMe, MuteMe Mini, MuteSync |

--- a/docs/hardware/devices/blyncusb20.md
+++ b/docs/hardware/devices/blyncusb20.md
@@ -1,0 +1,136 @@
+![BusyLight Project Logo][1]
+
+## Embrava Blynclight Early Models (VID 0x1130)
+
+These are early Blynclight USB status lights with vendor ID 0x1130, predating
+the Embrava rebrand. They use different protocols than the newer Embrava
+Blynclight family (VID 0x2C0D).
+
+Three variants are supported:
+- **BLYNCUSB10** (PID 0x0001, 0x0002): Uses the blynux 8-byte protocol
+- **BLYNCUSB20** (PID 0x1E00): Uses the TENX20 2-byte protocol
+
+### Physical Description
+
+Early Blynclight models with an LED indicator light, labeled "Blync" on the
+front with www.blynclight.com URL, and model number on the bottom.
+
+### Basic Human Interface Device Info
+
+| Variant | VID | PID | Interface | Protocol |
+|---------|-----|-----|-----------|----------|
+| BLYNCUSB10 | 0x1130 | 0x0001 | 1 | Blynux 8-byte feature report |
+| BLYNCUSB10 | 0x1130 | 0x0002 | 1 | Blynux 8-byte feature report |
+| BLYNCUSB20 | 0x1130 | 0x1E00 | 1 | TENX20 65-byte HID write |
+
+All variants support the same 7 predefined colors plus OFF.
+
+### Available Colors
+
+| Color   | Blynux Value | TENX20 Code |
+|---------|--------------|-------------|
+| WHITE   | 0x8          | 0x07        |
+| CYAN    | 0x9          | 0x17        |
+| MAGENTA | 0xA          | 0x20        |
+| BLUE    | 0xB          | 0x35        |
+| YELLOW  | 0xC          | 0x40        |
+| GREEN   | 0xD          | 0xD8        |
+| RED     | 0xE          | 0x60        |
+| OFF     | 0xF          | 0x73        |
+
+---
+
+## BLYNCUSB10 Protocol (PID 0x0001, 0x0002)
+
+This protocol was reverse-engineered and documented in the
+[blynux project](https://github.com/ticapix/blynux).
+
+### Command Format
+
+The command is an 8-byte payload sent via USB HID feature report:
+
+```C
+typedef struct {
+    unsigned int header[7]; /* Bytes 0-6: Constant 0x55, 0x53, 0x42, 0x43, 0x00, 0x40, 0x02 */
+    unsigned int color:  4; /* Bits 4-7 of byte 7: Color value from table above */
+    unsigned int footer: 4; /* Bits 0-3 of byte 7: Constant 0xF */
+} blynux_ctrl_t;
+```
+
+The base command payload is: `{ 0x55, 0x53, 0x42, 0x43, 0x00, 0x40, 0x02, 0x0F }`
+
+To set a color, the color value is shifted left by 4 bits and ORed with the
+footer nibble:
+
+```C
+data[7] = (color_mask << 4) | 0x0F;
+```
+
+### USB Transfer Details
+
+- bmRequestType: 0x21 (Host-to-device, Class, Interface)
+- bRequest: 9 (SET_REPORT)
+- wValue: 0x0200
+- wIndex: 1
+- wLength: 8
+
+This corresponds to a HID SET_REPORT request, which is handled via
+`send_feature_report` in the busylight-core library.
+
+---
+
+## BLYNCUSB20 Protocol (PID 0x1E00) - TENX20 Chipset
+
+This protocol was discovered by decompiling the official Blynclight.dll SDK.
+The TENX20 chipset uses a simpler two-step command protocol.
+
+### Command Format
+
+Commands are sent as 65-byte HID writes on interface 1:
+- Byte 0: Report ID (0x00)
+- Byte 1: Control code
+- Bytes 2-64: Padding (0x00)
+
+### Two-Step Command Sequence
+
+To set a color, two commands must be sent in sequence:
+
+1. **Reset/Prepare Command**: Send control code `0x73`
+2. **Color Command**: Send the TENX20 color code from the table above
+
+```python
+# Example: Set light to RED
+buffer = bytes([0x00, 0x73] + [0] * 63)  # Step 1: Reset
+device.write(buffer)
+
+buffer = bytes([0x00, 0x60] + [0] * 63)  # Step 2: RED (0x60)
+device.write(buffer)
+```
+
+---
+
+## Linux udev Rules
+
+To use the device without root privileges on Linux, add the following
+udev rules to `/etc/udev/rules.d/10-blyncusb.rules`:
+
+```
+SUBSYSTEM=="input", GROUP="input", MODE="0666"
+SUBSYSTEM=="usb", ATTRS{idVendor}=="1130", ATTRS{idProduct}=="0001", MODE:="666", GROUP="plugdev"
+SUBSYSTEM=="usb", ATTRS{idVendor}=="1130", ATTRS{idProduct}=="0002", MODE:="666", GROUP="plugdev"
+SUBSYSTEM=="usb", ATTRS{idVendor}=="1130", ATTRS{idProduct}=="1e00", MODE:="666", GROUP="plugdev"
+```
+
+## Limitations
+
+- No full RGB color control - only 7 predefined colors
+- No audio/sound playback capability
+- No flash/blink patterns (must be implemented in software)
+- No dim/bright control
+
+## References
+
+- [Blynux GitHub Repository](https://github.com/ticapix/blynux) - BLYNCUSB10 protocol
+- Decompiled Blynclight.dll SDK - TENX20 protocol for PID 0x1E00
+
+[1]: ../../assets/Unstacked-Logo-Light.png

--- a/src/busylight_core/__init__.py
+++ b/src/busylight_core/__init__.py
@@ -39,6 +39,7 @@ from .vendors.agile_innovative import (
     BlinkStickSquare,
     BlinkStickStrip,
 )
+from .vendors.blyncusb20 import Blyncusb10, Blyncusb20, Blyncusb20Lights, Blyncusb30
 from .vendors.compulab import CompuLabLights, FitStatUSB
 from .vendors.embrava import Blynclight, BlynclightMini, BlynclightPlus, EmbravaLights
 from .vendors.epos import Busylight, EPOSLights
@@ -63,6 +64,10 @@ __all__ = [
     "Blynclight",
     "BlynclightMini",
     "BlynclightPlus",
+    "Blyncusb10",
+    "Blyncusb20",
+    "Blyncusb20Lights",
+    "Blyncusb30",
     "BusyTag",
     "Busylight",
     "BusylightAlpha",

--- a/src/busylight_core/vendors/blyncusb20/__init__.py
+++ b/src/busylight_core/vendors/blyncusb20/__init__.py
@@ -1,0 +1,40 @@
+"""Embrava Blynclight BLYNCUSB10/BLYNCUSB20/BLYNCUSB30 Support
+
+Support for early Blynclight models with VID 0x1130:
+- BLYNCUSB10 (PID 0x0001, 0x0002): Uses blynux 8-byte feature report protocol
+- BLYNCUSB20/30 (PID 0x1E00): Uses TENX20 2-byte HID write protocol on interface 1
+
+These use a predefined color palette instead of full RGB control.
+
+Protocol sources:
+- https://github.com/ticapix/blynux (for PID 0x0001)
+- Decompiled Blynclight.dll SDK (for PID 0x1E00)
+"""
+
+from .blyncusb20 import (
+    Blyncusb10,
+    Blyncusb20,
+    Blyncusb30,
+    Tenx20Color,
+)
+from .blyncusb20_base import (
+    BLYNCUSB20_COLOR_TO_RGB,
+    Blyncusb20Base,
+    Blyncusb20Color,
+    rgb_to_blyncusb20_color,
+)
+
+# Backwards compatibility
+Blyncusb20Lights = Blyncusb20Base
+
+__all__ = [
+    "BLYNCUSB20_COLOR_TO_RGB",
+    "Blyncusb10",
+    "Blyncusb20",
+    "Blyncusb20Base",
+    "Blyncusb20Color",
+    "Blyncusb20Lights",
+    "Blyncusb30",
+    "Tenx20Color",
+    "rgb_to_blyncusb20_color",
+]

--- a/src/busylight_core/vendors/blyncusb20/blyncusb20.py
+++ b/src/busylight_core/vendors/blyncusb20/blyncusb20.py
@@ -1,0 +1,222 @@
+"""Embrava Blynclight BLYNCUSB20 Support
+
+Support for early Blynclight models with VID 0x1130.
+These use different protocols from the newer Embrava Blynclight devices.
+
+Three variants are supported:
+- BLYNCUSB10 (PID 0x0001, 0x0002): Uses blynux 8-byte protocol with feature report
+- BLYNCUSB20 (PID 0x1E00): Uses TENX20 2-byte protocol on interface 1
+
+Protocol information from:
+- https://github.com/ticapix/blynux (for PID 0x0001)
+- Decompiled Blynclight.dll SDK (for PID 0x1E00 TENX20 protocol)
+"""
+
+from enum import IntEnum
+from typing import TYPE_CHECKING, ClassVar
+
+from busylight_core.light import Light
+
+from .blyncusb20_base import (
+    BLYNCUSB20_COLOR_TO_RGB,
+    Blyncusb20Base,
+    Blyncusb20Color,
+    rgb_to_blyncusb20_color,
+)
+
+if TYPE_CHECKING:
+
+    from busylight_core.hardware import Hardware
+
+
+class Blyncusb10(Blyncusb20Base):
+    """Embrava Blynclight BLYNCUSB10 (PID 0x0001, 0x0002) USB status light.
+
+    This is an early Blynclight model (TENX10 chipset) that uses the
+    blynux 8-byte USB control transfer protocol. It supports 7 predefined
+    colors plus off.
+
+    Device specifications:
+    - VID: 0x1130
+    - PID: 0x0001 or 0x0002
+    - Interface: 1
+    - Protocol: 8-byte USB HID feature report (blynux protocol)
+    - Colors: 7 predefined + OFF
+    """
+
+    supported_device_ids: ClassVar[dict[tuple[int, int], str]] = {
+        (0x1130, 0x0001): "Blynclight BLYNCUSB10",
+        (0x1130, 0x0002): "Blynclight BLYNCUSB10",
+    }
+
+    @classmethod
+    def claims(cls, hardware: "Hardware") -> bool:
+        """Check if this class can control the given hardware device.
+
+        The BLYNCUSB10 requires interface 1 for control.
+
+        :param hardware: Hardware instance to test for compatibility
+        :return: True if this class can control the hardware device
+        """
+        return (
+            hardware.device_id in cls.supported_device_ids
+            and hardware.interface_number == 1
+        )
+
+
+# Backwards compatibility alias
+Blyncusb20 = Blyncusb10
+
+
+class Tenx20Color(IntEnum):
+    """Color codes for TENX20 chipset (PID 0x1E00).
+
+    These are single-byte color codes used in the TENX20 protocol.
+    The protocol sends 0x73 (reset) first, then the color code.
+    """
+
+    RED = 0x60
+    GREEN = 0xD8
+    BLUE = 0x35
+    YELLOW = 0x40
+    MAGENTA = 0x20
+    WHITE = 0x07
+    CYAN = 0x17
+    OFF = 0x73  # Also used as reset command
+
+
+# Map Blyncusb20Color to Tenx20Color
+BLYNCUSB20_TO_TENX20: dict[Blyncusb20Color, Tenx20Color] = {
+    Blyncusb20Color.RED: Tenx20Color.RED,
+    Blyncusb20Color.GREEN: Tenx20Color.GREEN,
+    Blyncusb20Color.BLUE: Tenx20Color.BLUE,
+    Blyncusb20Color.YELLOW: Tenx20Color.YELLOW,
+    Blyncusb20Color.MAGENTA: Tenx20Color.MAGENTA,
+    Blyncusb20Color.WHITE: Tenx20Color.WHITE,
+    Blyncusb20Color.CYAN: Tenx20Color.CYAN,
+    Blyncusb20Color.OFF: Tenx20Color.OFF,
+}
+
+
+class Blyncusb30(Light):
+    """Embrava Blynclight BLYNCUSB30 (PID 0x1E00) USB status light.
+
+    This variant uses the TENX20 chipset with a different protocol:
+    - 65-byte HID write on interface 1
+    - Two-step command: send 0x73 (reset), then color code
+    - Simple single-byte color codes (not the blynux bit-shifted format)
+
+    Device specifications:
+    - VID: 0x1130
+    - PID: 0x1E00
+    - Interface: 1
+    - Protocol: TENX20 (65-byte HID write, 2-step command)
+    - Colors: 7 predefined + OFF
+    """
+
+    supported_device_ids: ClassVar[dict[tuple[int, int], str]] = {
+        (0x1130, 0x1E00): "Blynclight BLYNCUSB20",
+    }
+
+    # TENX20 protocol uses 65-byte buffer (1 report ID + 64 data bytes)
+    _BUFFER_SIZE = 65
+
+    @staticmethod
+    def vendor() -> str:
+        """Return the vendor name for BLYNCUSB30 devices."""
+        return "Embrava"
+
+    def __init__(self, *args: object, **kwargs: object) -> None:
+        """Initialize the BLYNCUSB30 device."""
+        super().__init__(*args, **kwargs)
+        self._current_color: Blyncusb20Color = Blyncusb20Color.OFF
+        self._rgb_color: tuple[int, int, int] = (0, 0, 0)
+
+    @classmethod
+    def claims(cls, hardware: "Hardware") -> bool:
+        """Check if this class can control the given hardware device.
+
+        The BLYNCUSB30 requires interface 1 for control.
+
+        :param hardware: Hardware instance to test for compatibility
+        :return: True if this class can control the hardware device
+        """
+        return (
+            hardware.device_id in cls.supported_device_ids
+            and hardware.interface_number == 1
+        )
+
+    def _make_command(self, code: int) -> bytes:
+        """Create a 65-byte command buffer with the given control code.
+
+        :param code: The control code byte
+        :return: 65-byte command buffer
+        """
+        return bytes([0x00, code] + [0] * 63)
+
+    def __bytes__(self) -> bytes:
+        """Return the device state as bytes for USB communication.
+
+        Note: The TENX20 protocol uses a two-step command sequence,
+        so this returns the color command (step 2). The update() method
+        handles sending both commands in sequence.
+        """
+        tenx20_color = BLYNCUSB20_TO_TENX20.get(
+            self._current_color, Tenx20Color.OFF
+        )
+        return self._make_command(tenx20_color)
+
+    def update(self) -> None:
+        """Write the current state to the hardware device.
+
+        The TENX20 protocol requires a two-step command:
+        1. Send 0x73 (reset/prepare)
+        2. Send color code
+        """
+        # Step 1: Send reset command
+        self.hardware.handle.write(self._make_command(0x73))
+
+        # Step 2: Send color code
+        tenx20_color = BLYNCUSB20_TO_TENX20.get(
+            self._current_color, Tenx20Color.OFF
+        )
+        self.hardware.handle.write(self._make_command(tenx20_color))
+
+    @property
+    def color(self) -> tuple[int, int, int]:
+        """Tuple of RGB color values (approximated from BLYNCUSB20 color)."""
+        return self._rgb_color
+
+    @color.setter
+    def color(self, value: tuple[int, int, int]) -> None:
+        """Set the RGB color values (mapped to nearest BLYNCUSB20 color)."""
+        self._rgb_color = value
+        self._current_color = rgb_to_blyncusb20_color(*value)
+
+    @property
+    def blyncusb20_color(self) -> Blyncusb20Color:
+        """Get the current BLYNCUSB20 color value."""
+        return self._current_color
+
+    @blyncusb20_color.setter
+    def blyncusb20_color(self, value: Blyncusb20Color) -> None:
+        """Set the BLYNCUSB20 color directly."""
+        self._current_color = value
+        self._rgb_color = BLYNCUSB20_COLOR_TO_RGB.get(value, (0, 0, 0))
+
+    def on(self, color: tuple[int, int, int], led: int = 0) -> None:
+        """Turn on the device with the specified color.
+
+        Note: The device only supports 7 predefined colors.
+        The RGB color will be mapped to the nearest available color.
+
+        :param color: RGB color tuple (red, green, blue)
+        :param led: LED index (not used by this device)
+        """
+        self.color = color
+        self.update()
+
+    def reset(self) -> None:
+        """Reset the device to its default state (off)."""
+        self.blyncusb20_color = Blyncusb20Color.OFF
+        self.update()

--- a/src/busylight_core/vendors/blyncusb20/blyncusb20_base.py
+++ b/src/busylight_core/vendors/blyncusb20/blyncusb20_base.py
@@ -1,0 +1,173 @@
+"""Embrava Blynclight BLYNCUSB20 base class.
+
+This is an early variant of the Blynclight, using USB control transfers
+with a predefined color palette instead of full RGB control.
+
+Device specifications from https://github.com/ticapix/blynux:
+- VID:PID: 0x1130:0x0001
+- 8-byte command payload
+- Predefined color palette (8 colors including OFF)
+"""
+
+from enum import IntEnum
+from typing import TYPE_CHECKING
+
+from busylight_core.light import Light
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+
+class Blyncusb20Color(IntEnum):
+    """Predefined color values for BLYNCUSB20 devices.
+
+    The BLYNCUSB20 uses a 4-bit color mask that maps to
+    predefined colors. Full RGB control is not available.
+    """
+
+    WHITE = 0x8
+    CYAN = 0x9
+    MAGENTA = 0xA
+    BLUE = 0xB
+    YELLOW = 0xC
+    GREEN = 0xD
+    RED = 0xE
+    OFF = 0xF
+
+
+def rgb_to_blyncusb20_color(red: int, green: int, blue: int) -> Blyncusb20Color:
+    """Map an RGB color to the nearest BLYNCUSB20 predefined color.
+
+    Since the BLYNCUSB20 device only supports 7 colors plus OFF,
+    this function attempts to find the best match based on
+    the RGB values provided.
+
+    :param red: Red component (0-255)
+    :param green: Green component (0-255)
+    :param blue: Blue component (0-255)
+    :return: The closest Blyncusb20Color match
+    """
+    # If all components are very low, return OFF
+    if red < 32 and green < 32 and blue < 32:
+        return Blyncusb20Color.OFF
+
+    # Determine dominant colors
+    max_val = max(red, green, blue)
+    threshold = max_val * 0.5  # 50% of max to be considered "on"
+
+    r_on = red >= threshold
+    g_on = green >= threshold
+    b_on = blue >= threshold
+
+    # Map RGB combinations (r_on, g_on, b_on) to Blyncusb20 colors
+    color_map = {
+        (True, True, True): Blyncusb20Color.WHITE,
+        (True, True, False): Blyncusb20Color.YELLOW,
+        (True, False, True): Blyncusb20Color.MAGENTA,
+        (False, True, True): Blyncusb20Color.CYAN,
+        (True, False, False): Blyncusb20Color.RED,
+        (False, True, False): Blyncusb20Color.GREEN,
+        (False, False, True): Blyncusb20Color.BLUE,
+    }
+
+    return color_map.get((r_on, g_on, b_on), Blyncusb20Color.OFF)
+
+
+# Reverse mapping from Blyncusb20Color to approximate RGB values
+BLYNCUSB20_COLOR_TO_RGB: dict[Blyncusb20Color, tuple[int, int, int]] = {
+    Blyncusb20Color.WHITE: (255, 255, 255),
+    Blyncusb20Color.CYAN: (0, 255, 255),
+    Blyncusb20Color.MAGENTA: (255, 0, 255),
+    Blyncusb20Color.BLUE: (0, 0, 255),
+    Blyncusb20Color.YELLOW: (255, 255, 0),
+    Blyncusb20Color.GREEN: (0, 255, 0),
+    Blyncusb20Color.RED: (255, 0, 0),
+    Blyncusb20Color.OFF: (0, 0, 0),
+}
+
+
+class Blyncusb20Base(Light):
+    """Base class for Embrava Blynclight BLYNCUSB20 devices.
+
+    The BLYNCUSB20 uses a different protocol than newer Embrava Blynclights:
+    - 8-byte USB control transfer command
+    - Predefined color palette (7 colors + OFF)
+    - No audio support
+
+    Command structure:
+    - Bytes 0-6: Header (0x55, 0x53, 0x42, 0x43, 0x00, 0x40, 0x02)
+    - Byte 7: Color mask (color_value << 4) | 0x0f
+    """
+
+    # Base command payload from blynux C code
+    _BASE_COMMAND = bytes([0x55, 0x53, 0x42, 0x43, 0x00, 0x40, 0x02, 0x0F])
+
+    @staticmethod
+    def vendor() -> str:
+        """Return the vendor name for BLYNCUSB20 devices."""
+        return "Embrava"
+
+    def __init__(self, *args: object, **kwargs: object) -> None:
+        """Initialize the BLYNCUSB20 device."""
+        super().__init__(*args, **kwargs)
+        self._current_color: Blyncusb20Color = Blyncusb20Color.OFF
+        self._rgb_color: tuple[int, int, int] = (0, 0, 0)
+
+    def __bytes__(self) -> bytes:
+        """Return the device state as bytes for USB communication.
+
+        The command format for the original BLYNCUSB20 (0x0001) is:
+        - 7 header bytes: 0x55, 0x53, 0x42, 0x43, 0x00, 0x40, 0x02
+        - 1 color byte: (color_mask << 4) | 0x0f
+
+        Uses send_feature_report for USB control transfers.
+        """
+        color_byte = (self._current_color.value << 4) | 0x0F
+        return bytes([0x55, 0x53, 0x42, 0x43, 0x00, 0x40, 0x02, color_byte])
+
+    @property
+    def write_strategy(self) -> "Callable[[bytes], None]":
+        """The write method used by this light.
+
+        The original BLYNCUSB20 (0x0001) uses send_feature_report.
+        """
+        return self.hardware.handle.send_feature_report
+
+    @property
+    def color(self) -> tuple[int, int, int]:
+        """Tuple of RGB color values (approximated from BLYNCUSB20 color)."""
+        return self._rgb_color
+
+    @color.setter
+    def color(self, value: tuple[int, int, int]) -> None:
+        """Set the RGB color values (mapped to nearest BLYNCUSB20 color)."""
+        self._rgb_color = value
+        self._current_color = rgb_to_blyncusb20_color(*value)
+
+    @property
+    def blyncusb20_color(self) -> Blyncusb20Color:
+        """Get the current BLYNCUSB20 color value."""
+        return self._current_color
+
+    @blyncusb20_color.setter
+    def blyncusb20_color(self, value: Blyncusb20Color) -> None:
+        """Set the BLYNCUSB20 color directly."""
+        self._current_color = value
+        self._rgb_color = BLYNCUSB20_COLOR_TO_RGB.get(value, (0, 0, 0))
+
+    def on(self, color: tuple[int, int, int], led: int = 0) -> None:
+        """Turn on the device with the specified color.
+
+        Note: The BLYNCUSB20 only supports 7 predefined colors.
+        The RGB color will be mapped to the nearest available color.
+
+        :param color: RGB color tuple (red, green, blue)
+        :param led: LED index (not used by BLYNCUSB20 devices)
+        """
+        self.color = color
+        self.update()
+
+    def reset(self) -> None:
+        """Reset the device to its default state (off)."""
+        self.blyncusb20_color = Blyncusb20Color.OFF
+        self.update()

--- a/src/busylight_core/vendors/embrava/blynclight_mini.py
+++ b/src/busylight_core/vendors/embrava/blynclight_mini.py
@@ -14,6 +14,8 @@ class BlynclightMini(BlynclightPlus):
     """
 
     supported_device_ids: ClassVar[dict[tuple[int, int], str]] = {
+        (0x2C0D, 0x0003): "Blynclight Mini",
         (0x2C0D, 0x000A): "Blynclight Mini",
         (0x0E53, 0x2517): "Blynclight Mini",
+        (0x0E53, 0x2519): "Blynclight Mini",
     }


### PR DESCRIPTION
## Summary

Add support for early Blynclight USB status lights with vendor ID 0x1130:

- BLYNCUSB10 (PID 0x0001, 0x0002): Uses 8-byte feature report protocol
- BLYNCUSB20/TENX20 (PID 0x1E00): Uses 2-byte HID write protocol

Also adds missing PIDs to BlynclightMini.

Mostly generated by guiding Claude Opus along.

## Test Plan

Tested on an actual BLYNCUSB20 - the BLYNCUSB10 code was code I had used on a BLYNCUSB10 successfully at some point in the past and was in my notes.  The PIDs for BlynclightMini came from another library that actually had the proper protocol for the BLYNCUSB20 as well.
