### PR TITLE
docs: rewrite documentation to match actual API

### DIFF
--- a/docs/getting-started/configuration.md
+++ b/docs/getting-started/configuration.md
@@ -10,15 +10,9 @@ Import and use the library directly in your Python code:
 from busylight_core import Light, NoLightsFoundError
 
 try:
-    # Get the first available light
     light = Light.first_light()
-    
-    # Turn on red
     light.on((255, 0, 0))
-    
-    # Turn off
     light.off()
-    
 except NoLightsFoundError:
     print("No lights found")
 ```
@@ -33,11 +27,11 @@ from busylight_core import Light, NoLightsFoundError
 try:
     # Standard initialization - resets device and acquires exclusive access
     light = Light.first_light()
-    
+
     # Explicitly control initialization behavior
-    light = Light.first_light(reset=True, exclusive=True)   # Default behavior
-    light = Light.first_light(reset=False, exclusive=False) # No reset, shared access
-    
+    light = Light.first_light(reset=True, exclusive=True)    # Default behavior
+    light = Light.first_light(reset=False, exclusive=False)  # No reset, shared access
+
 except NoLightsFoundError:
     print("No lights found")
 ```

--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -20,61 +20,56 @@ uv add busylight_core
 
 After [installing](installation.md) busylight_core, you can start controlling lights in your Python code:
 
-**Option 1: Any compatible device (recommended for simple use cases)**
+**Any compatible device (recommended for simple use cases):**
+
 ```python
-from busylight_core import Light
+from busylight_core import Light, NoLightsFoundError
 
-# Find all connected lights
-lights = Light.all_lights()
-print(f"Found {len(lights)} device(s)")
-
-# Control the first light found
-if lights:
-    light = lights[0]
+try:
+    light = Light.first_light()
     light.on((255, 0, 0))  # Turn on red
-    light.off()           # Turn off
-else:
+    light.off()             # Turn off
+except NoLightsFoundError:
     print("No compatible lights found. Check your device connection.")
 ```
 
-**Option 2: Vendor-specific devices (recommended for production)**
+**Vendor-specific devices (recommended for vendor-specific features):**
+
 ```python
-from busylight_core import EmbravaLights, LuxaforLights
+from busylight_core import EmbravaLights, KuandoLights, NoLightsFoundError
 
-# Get devices from specific vendors
-embrava_lights = EmbravaLights.all_lights()
-luxafor_lights = LuxaforLights.all_lights()
+# Embrava devices support dim/bright and flash
+try:
+    light = EmbravaLights.first_light()
+    light.on((255, 0, 0))
+    light.dim()       # Reduce brightness
+    light.bright()    # Restore full brightness
+    light.flash((255, 255, 0))  # Flash yellow
+except NoLightsFoundError:
+    print("No Embrava devices found")
 
-# Use Embrava devices if available
-if embrava_lights:
-    light = embrava_lights[0]
-    light.on((255, 0, 0), sound=True)  # Red with audio (Embrava-specific)
-    light.dim()  # Reduce brightness
-elif luxafor_lights:
-    light = luxafor_lights[0] 
-    light.on((255, 0, 0))  # Red light
-    # Check for multi-LED support
-    if hasattr(light, 'on') and 'led' in light.on.__annotations__:
-        for i in range(6):  # Flag has 6 LEDs
-            light.on((0, 255, 0), led=i)  # Green on each LED
-else:
-    print("No Embrava or Luxafor devices found")
+# Kuando devices manage keepalive automatically
+try:
+    light = KuandoLights.first_light()
+    light.on((0, 255, 0))  # Keepalive starts automatically
+except NoLightsFoundError:
+    print("No Kuando devices found")
 ```
 
 ## Discovering Your Device
 
 **Check all connected devices:**
+
 ```python
 from busylight_core import Light
 
-# Get all available lights
 lights = Light.all_lights()
 
 if lights:
     for i, light in enumerate(lights):
         print(f"Light {i}: {light.vendor()} {light.name}")
-        print(f"  Device ID: {light.device_id}")
         print(f"  Hardware: {light.hardware.manufacturer_string}")
+        print(f"  Path: {light.path}")
 else:
     print("No lights found. Try:")
     print("1. Check USB connection")
@@ -83,16 +78,16 @@ else:
 ```
 
 **Check devices by vendor:**
+
 ```python
 from busylight_core import (
-    EmbravaLights, KuandoLights, LuxaforLights, 
+    EmbravaLights, KuandoLights, LuxaforLights,
     AgileInnovativeLights, ThingMLights, MuteMeLights
 )
 
-# Check what vendors you have connected
 vendors = [
     ("Embrava", EmbravaLights),
-    ("Kuando", KuandoLights), 
+    ("Kuando", KuandoLights),
     ("Luxafor", LuxaforLights),
     ("BlinkStick", AgileInnovativeLights),
     ("ThingM", ThingMLights),
@@ -105,121 +100,92 @@ for vendor_name, vendor_class in vendors:
         print(f"{vendor_name}: {len(devices)} device(s)")
         for device in devices:
             print(f"  - {device.name}")
-    else:
-        print(f"{vendor_name}: No devices found")
 ```
 
 ## Basic Light Control
 
 ### Colors
 
-**Universal approach (works with any device):**
 ```python
 from busylight_core import Light, NoLightsFoundError
 
-try:
-    light = Light.first_light()  # Get the first available light
-    
-    # Basic colors (RGB tuples, values 0-255)
-    light.on((255, 0, 0))    # Red
-    light.on((0, 255, 0))    # Green  
-    light.on((0, 0, 255))    # Blue
-    light.on((255, 255, 0))  # Yellow
-    light.on((255, 0, 255))  # Magenta
-    light.on((0, 255, 255))  # Cyan
-    light.on((255, 255, 255)) # White
-    
-    # Turn off
-    light.off()
-    
-except NoLightsFoundError:
-    print("No lights available")
-```
-
-**Vendor-specific approach (recommended for specific features):**
-```python
-from busylight_core import EmbravaLights, KuandoLights, NoLightsFoundError
-
-# Embrava devices with audio
-try:
-    light = EmbravaLights.first_light()
-    light.on((255, 0, 0), sound=True)  # Red with sound
-    light.dim()  # Reduce brightness
-    light.bright()  # Restore brightness
-except NoLightsFoundError:
-    print("No Embrava devices found")
-
-# Kuando devices with keepalive
-try:
-    light = KuandoLights.first_light()
-    light.on((0, 255, 0))
-    light.keepalive()  # Required for Kuando devices
-except NoLightsFoundError:
-    print("No Kuando devices found")
-```
-
-### Flash Patterns
-
-**Universal approach with fallback:**
-```python
-from busylight_core import Light, NoLightsFoundError
-import time
-
-# Flash patterns work on devices with hardware flash support
 try:
     light = Light.first_light()
-    
-    # Check if device supports flashing
-    if hasattr(light, 'flash'):
-        light.flash((255, 0, 0))  # Flash red (device-specific timing)
-        print("Device supports hardware flash")
-    else:
-        # Software flash fallback
-        for _ in range(3):
-            light.on((255, 0, 0))
-            time.sleep(0.5)
-            light.off()
-            time.sleep(0.5)
-        print("Using software flash fallback")
-        
+
+    # Basic colors (RGB tuples, values 0-255)
+    light.on((255, 0, 0))      # Red
+    light.on((0, 255, 0))      # Green
+    light.on((0, 0, 255))      # Blue
+    light.on((255, 255, 0))    # Yellow
+    light.on((255, 0, 255))    # Magenta
+    light.on((0, 255, 255))    # Cyan
+    light.on((255, 255, 255))  # White
+
+    # Turn off
+    light.off()
+
+    # Check if light is on
+    if light.is_lit:
+        print("Light is currently on")
+
 except NoLightsFoundError:
     print("No lights available")
 ```
 
-**Vendor-specific flash patterns:**
-```python
-from busylight_core import EmbravaLights, KuandoLights
+### Flash Patterns (Embrava Only)
 
-# Embrava devices have configurable flash speeds
+Only Embrava Blynclight devices have hardware flash support:
+
+```python
+from busylight_core import EmbravaLights, NoLightsFoundError
+from busylight_core.vendors.embrava.implementation import FlashSpeed
+
 try:
     light = EmbravaLights.first_light()
-    light.flash((255, 165, 0))  # Orange flash with default speed
-    # Some Embrava devices support speed control
-    # light.flash((255, 0, 0), speed="fast")
+
+    # Flash with default speed (slow)
+    light.flash((255, 0, 0))
+
+    # Flash with specific speed
+    light.flash((255, 165, 0), speed=FlashSpeed.slow)
+
+    # Stop flashing, return to solid color
+    light.stop_flashing()
+
 except NoLightsFoundError:
     print("No Embrava devices found")
-
-# Kuando devices have built-in flash patterns  
-try:
-    light = KuandoLights.first_light()
-    light.flash((255, 0, 255))  # Magenta flash
-    light.keepalive()  # Don't forget keepalive for Kuando
-except NoLightsFoundError:
-    print("No Kuando devices found")
 ```
 
+For devices without hardware flash, implement it in software:
+
+```python
+import time
+from busylight_core import Light, NoLightsFoundError
+
+try:
+    light = Light.first_light()
+
+    # Software flash fallback
+    for _ in range(3):
+        light.on((255, 0, 0))
+        time.sleep(0.5)
+        light.off()
+        time.sleep(0.5)
+
+except NoLightsFoundError:
+    print("No lights available")
+```
 
 ## Device Compatibility
 
-Different devices have different capabilities. Use the [Device Capabilities](../user-guide/device-capabilities.md) guide to understand what features your hardware supports.
+Different devices have different capabilities. See [Device Capabilities](../user-guide/device-capabilities.md) for a full breakdown of what each device supports.
 
 ## Configuration
 
-Busylight Core can be configured using environment variables or a configuration file. See [Configuration](configuration.md) for details.
+Busylight Core can be configured at initialization time. See [Configuration](configuration.md) for details.
 
 ## Next Steps
 
 - Learn about specific device capabilities: [Device Capabilities](../user-guide/device-capabilities.md)
-- See comprehensive examples: [Examples](../user-guide/examples.md) 
+- See comprehensive examples: [Examples](../user-guide/examples.md)
 - Check out the [API Reference](../reference/index.md)
-- Read the [Contributing Guide](../contributing.md) if you want to contribute

--- a/docs/index.md
+++ b/docs/index.md
@@ -17,28 +17,25 @@ pip install busylight_core
 Then use it in your Python code:
 
 ```python
-from busylight_core import Light
+from busylight_core import Light, NoLightsFoundError
 
-# Find all connected lights
-lights = Light.available()
-print(f"Found {len(lights)} device(s)")
-
-# Control a light
-if lights:
-    light = lights[0]
+try:
+    light = Light.first_light()
     light.on((255, 0, 0))  # Turn on red
-    light.off()           # Turn off
+    light.off()             # Turn off
+except NoLightsFoundError:
+    print("No compatible lights found")
 ```
 
 ## Features
 
 - **Multi-Vendor Support** - Control devices from 9+ vendors (Embrava, Kuando, Luxafor, ThingM, and more)
-- **Multiple Connection Types** - HID, Serial, and Bluetooth device support
-- **Rich Light Control** - Colors, brightness, flash patterns, fade effects
-- **Audio Capabilities** - Sound playback and mute/unmute on supported devices
-- **Input Detection** - Button press handling on interactive devices
-- **Multi-LED Support** - Control devices with 1-192 individual LEDs
-- **Async Task Management** - Built-in support for animations and effects
+- **Multiple Connection Types** - HID and Serial device support
+- **Rich Light Control** - Colors, brightness, flash patterns
+- **Audio Capabilities** - Sound playback on Embrava Blynclight Plus devices
+- **Input Detection** - Button state on MuteMe and Luxafor Mute devices
+- **Multi-LED Support** - Control devices with 1-64+ individual LEDs (BlinkStick, Luxafor Flag)
+- **Async Task Management** - Built-in support for periodic tasks and animations
 - **Extensible Architecture** - Easy to add support for new devices
 - **Object-Oriented API** - Clean, intuitive programming interface
 
@@ -56,6 +53,7 @@ For detailed installation instructions, see [Installation](getting-started/insta
 ## License
 
 This project is licensed under the Apache-2.0 license.
+
 ## Support
 
 - [GitHub Issues](https://github.com/JnyJny/busylight_core/issues)

--- a/docs/user-guide/device-capabilities.md
+++ b/docs/user-guide/device-capabilities.md
@@ -1,289 +1,250 @@
 # Device Capabilities Reference
 
-This guide provides detailed information about each supported device's capabilities, helping you choose the right device and understand what features are available for your specific hardware.
+This guide provides detailed information about each supported device's capabilities.
 
 ## Capability Overview
 
 | Feature | Devices | Description |
 |---------|---------|-------------|
-| **Basic RGB Color** | All 26 devices | Standard 0-255 RGB color control |
-| **Hardware Flash** | 13 devices | Built-in flash patterns with configurable speed |
-| **Multi-LED Control** | 7 device variants | Control individual LEDs (2-192 LEDs) |
-| **Audio/Sound** | 5 devices | Built-in speaker with configurable sounds |
-| **Button Input** | 4 devices | Physical button state detection |
-| **Advanced Programming** | 3 devices | Pattern storage and custom sequences |
+| **Basic RGB Color** | All devices | `on(color)` / `off()` with RGB tuples (0-255) |
+| **Hardware Flash** | Embrava (3 devices) | `flash(color, speed)` with `FlashSpeed` enum |
+| **Dim/Bright** | Embrava (3 devices) | `dim()` / `bright()` for brightness control |
+| **Audio Playback** | Blynclight Plus (1 device) | `play_sound(music, volume, repeat)` |
+| **Multi-LED Control** | BlinkStick variants, Luxafor Flag | `on(color, led=N)` for individual LEDs |
+| **Button Input** | MuteMe (3 devices), Luxafor Mute | `is_button` / `button_on` properties |
+| **Auto Keepalive** | Kuando (2 devices) | Managed automatically by `on()` / `off()` |
 
-## Vendor Summary
+## Vendor Details
 
 ### Embrava (3 devices)
-Professional meeting status lights with audio capabilities.
 
-| Device | LEDs | Flash | Audio | Special Features |
-|--------|------|-------|-------|------------------|
-| **Blynclight** | 1 | ✓ | ✓ | Industry standard |
-| **Blynclight Mini** | 1 | ✓ | ✓ | Compact form |
-| **Blynclight Plus** | 1 | ✓ | ✓ | Enhanced brightness |
+Professional meeting status lights with flash, brightness, and audio capabilities.
 
-**Usage Example:**
+| Device | Flash | Dim/Bright | Audio | Special |
+|--------|-------|------------|-------|---------|
+| **Blynclight** | Yes | Yes | No | Industry standard |
+| **Blynclight Mini** | Yes | Yes | No | Compact form |
+| **Blynclight Plus** | Yes | Yes | Yes | `play_sound()`, `mute()`, `unmute()` |
+
+**Usage:**
 ```python
-from busylight_core import EmbravaLights, Blynclight
+from busylight_core import EmbravaLights, BlynclightPlus, NoLightsFoundError
 
-# Get all Embrava devices (any model)
-embrava_lights = EmbravaLights.all_lights()
-if embrava_lights:
-    light = embrava_lights[0]
-    light.on((255, 0, 0), sound=True)  # Red with audio alert
-    light.flash((255, 255, 0))         # Flash yellow
+# Any Embrava device - flash and brightness
+try:
+    light = EmbravaLights.first_light()
+    light.on((255, 0, 0))
+    light.dim()
+    light.bright()
+    light.flash((255, 255, 0))
+    light.stop_flashing()
+except NoLightsFoundError:
+    pass
 
-# Or get specific Blynclight devices only
-blynclights = Blynclight.all_lights()
-if blynclights:
-    light = blynclights[0]
-    light.dim()  # Reduce brightness
+# Blynclight Plus only - audio
+try:
+    light = BlynclightPlus.first_light()
+    light.play_sound(music=0, volume=2)
+    light.stop_sound()
+    light.mute()
+    light.unmute()
+except NoLightsFoundError:
+    pass
 ```
 
 ### Kuando (2 devices)
-High-quality Nordic design status lights.
 
-| Device | LEDs | Flash | Audio | Special Features |
-|--------|------|-------|-------|------------------|
-| **Busylight Alpha** | 1 | ✓ | ✗ | Multiple USB IDs |
-| **Busylight Omega** | 1 | ✓ | ✗ | Premium model |
+Nordic-design status lights with automatic keepalive management.
 
-**Usage Example:**
+| Device | Flash | Audio | Special |
+|--------|-------|-------|---------|
+| **Busylight Alpha** | No | No | Multiple USB IDs, auto keepalive |
+| **Busylight Omega** | No | No | Premium model, auto keepalive |
+
+**Usage:**
 ```python
-from busylight_core import KuandoLights, BusylightAlpha
+from busylight_core import KuandoLights, BusylightAlpha, NoLightsFoundError
 
-# Get all Kuando devices (any model)
-kuando_lights = KuandoLights.all_lights()
-for light in kuando_lights:
-    light.on((0, 255, 0))  # Green
-
-# Or get specific Alpha devices only
-alpha_lights = BusylightAlpha.all_lights()
-if alpha_lights:
-    alpha = alpha_lights[0]
-    alpha.on((255, 165, 0))  # Orange
+try:
+    light = KuandoLights.first_light()
+    light.on((0, 255, 0))   # Keepalive starts automatically
+    light.off()              # Keepalive stops automatically
+except NoLightsFoundError:
+    pass
 ```
 
+**Note on ringtones:** The Kuando protocol supports 9 built-in ringtones (`Ring` enum: OpenOffice, Quiet, Funky, FairyTale, KuandoTrain, TelephoneNordic, TelephoneOriginal, TelephonePickMeUp, Buzz) with volume control (0-3) at the command level. However, these are **not exposed through the public `on()` API**. The `Step.jump()` command in `busylight_core.vendors.kuando.implementation.commands` accepts `ringtone` and `volume` parameters for direct protocol access.
+
 ### Luxafor (5 devices)
-Versatile devices with multi-LED support and button input.
 
-| Device | LEDs | Flash | Audio | Special Features |
-|--------|------|-------|-------|------------------|
-| **Flag** | 6 | ✓ | ✗ | Multi-zone control |
-| **Orb** | 1 | ✓ | ✗ | Spherical design |
-| **Bluetooth** | 1 | ✓ | ✗ | Wireless capable |
-| **Mute** | 1 | ✓ | ✗ | Button input |
-| **Busy Tag** | 1 | ✗ | ✗ | ASCII text protocol |
+Versatile devices including multi-LED and button-equipped models.
 
-**Usage Example:**
+| Device | LEDs | Flash | Button | Special |
+|--------|------|-------|--------|---------|
+| **Flag** | 6 | No | No | Multi-LED control via `led` param |
+| **Orb** | 1 | No | No | Spherical design |
+| **Bluetooth** | 1 | No | No | Wireless capable |
+| **Mute** | 1 | No | Yes | `is_button`, `button_on` |
+| **Busy Tag** | 1 | No | No | ASCII text protocol |
+
+**Usage:**
 ```python
-from busylight_core import LuxaforLights, Flag
+from busylight_core import Flag, NoLightsFoundError
+from busylight_core.vendors.luxafor import Mute
 
-# Get all Luxafor devices (any model)
-luxafor_lights = LuxaforLights.all_lights()
-if luxafor_lights:
-    light = luxafor_lights[0]
-    light.on((0, 0, 255))  # Works on any Luxafor device
-
-# Multi-LED control with Flag specifically
-flags = Flag.all_lights()
-if flags:
-    flag = flags[0]
-    # Control individual LEDs
+# Multi-LED with Flag
+try:
+    flag = Flag.first_light()
     for i in range(6):
         flag.on((255, 0, 0), led=i)  # Individual LED control
+    flag.on((0, 255, 0))             # All LEDs (led=0 default)
+except NoLightsFoundError:
+    pass
+
+# Button with Luxafor Mute
+try:
+    mute = Mute.first_light()
+    if mute.is_button and mute.button_on:
+        mute.on((255, 0, 0))  # Red when pressed
+except NoLightsFoundError:
+    pass
 ```
 
 ### Agile Innovative BlinkStick (6 variants)
+
 Flexible multi-LED strips and matrices for creative applications.
 
-| Device | LEDs | Flash | Audio | Special Features |
-|--------|------|-------|-------|------------------|
-| **BlinkStick** | 1 | ✗ | ✗ | Basic model |
-| **BlinkStick Nano** | 2 | ✗ | ✗ | Dual LED |
-| **BlinkStick Square** | 8 | ✗ | ✗ | 8-LED matrix |
-| **BlinkStick Strip** | 8 | ✗ | ✗ | LED strip |
-| **BlinkStick Flex** | 32 | ✗ | ✗ | Flexible strip |
-| **BlinkStick Pro** | 64 | ✗ | ✗ | Professional strip |
+| Device | LEDs | Special |
+|--------|------|---------|
+| **BlinkStick** | 1 | Basic model |
+| **BlinkStick Nano** | 2 | Dual LED |
+| **BlinkStick Square** | 8 | 8-LED matrix |
+| **BlinkStick Strip** | 8 | LED strip |
+| **BlinkStick Flex** | 32 | Flexible strip |
+| **BlinkStick Pro** | 64 | Professional strip |
 
-**Usage Example:**
+**Usage:**
 ```python
-from busylight_core import AgileInnovativeLights, BlinkStickPro
+from busylight_core import AgileInnovativeLights, BlinkStickPro, NoLightsFoundError
 
-# Get all BlinkStick devices (any variant)
-blinkstick_lights = AgileInnovativeLights.all_lights()
-if blinkstick_lights:
-    light = blinkstick_lights[0]
-    light.on((255, 0, 255))  # Works on any BlinkStick
+# Any BlinkStick
+try:
+    light = AgileInnovativeLights.first_light()
+    light.on((255, 0, 255))
+except NoLightsFoundError:
+    pass
 
-# Multi-LED animations with BlinkStick Pro specifically
-strips = BlinkStickPro.all_lights()
-if strips:
-    strip = strips[0]
-    # Create rainbow effect
+# Multi-LED with BlinkStick Pro
+try:
+    strip = BlinkStickPro.first_light()
     colors = [(255,0,0), (255,127,0), (255,255,0), (0,255,0), (0,0,255)]
     for i, color in enumerate(colors):
         strip.on(color, led=i)
+except NoLightsFoundError:
+    pass
 ```
 
 ### ThingM (1 device)
-Popular maker-friendly device with advanced programming.
 
-| Device | LEDs | Flash | Audio | Special Features |
-|--------|------|-------|-------|------------------|
-| **Blink(1)** | 2 | ✗ | ✗ | Pattern storage, fade effects |
+Popular maker-friendly device with dual LEDs.
 
-**Usage Example:**
+| Device | LEDs | Special |
+|--------|------|---------|
+| **Blink(1)** | 2 | Dual LED control |
+
+**Usage:**
 ```python
-from busylight_core import ThingMLights, Blink1
+from busylight_core import Blink1, NoLightsFoundError
 
-# Get all ThingM devices (currently just Blink1)
-thingm_lights = ThingMLights.all_lights()
-if thingm_lights:
-    light = thingm_lights[0]
-    light.on((255, 255, 255))  # Bright white
-
-# Advanced fade effects with Blink1 specifically
-blink1s = Blink1.all_lights()
-if blink1s:
-    blink = blink1s[0]
-    # Hardware fade (if supported)
-    if hasattr(blink, 'fade'):
-        blink.fade((255, 0, 0), duration=2.0)
+try:
+    blink = Blink1.first_light()
+    blink.on((255, 0, 0), led=0)  # First LED
+    blink.on((0, 0, 255), led=1)  # Second LED
+    blink.on((255, 255, 255))     # Both LEDs
+except NoLightsFoundError:
+    pass
 ```
 
 ### MuteMe (3 devices)
+
 Specialized mute button devices with status indication.
 
-| Device | LEDs | Flash | Audio | Special Features |
-|--------|------|-------|-------|------------------|
-| **MuteMe Original** | 1 | ✗ | ✗ | Button input, status LED |
-| **MuteMe Mini** | 1 | ✗ | ✗ | Compact button |
-| **MuteSync Button** | 1 | ✗ | ✗ | Sync-enabled |
+| Device | Button | Special |
+|--------|--------|---------|
+| **MuteMe Original** | Yes | `is_button`, `button_on` |
+| **MuteMe Mini** | Yes | Compact form |
+| **MuteSync Button** | Yes | `is_button`, `button_on` |
 
-**Usage Example:**
+**Usage:**
 ```python
-from busylight_core import MuteMeLights, MuteMe
+from busylight_core import MuteMe, MuteMeLights, NoLightsFoundError
 
-# Get all MuteMe devices (any model)
-muteme_lights = MuteMeLights.all_lights()
-for light in muteme_lights:
-    if light.is_button and light.button_pressed():
-        light.on((255, 0, 0))  # Red when muted
-    else:
-        light.on((0, 255, 0))  # Green when unmuted
-
-# Or get specific MuteMe Original devices
-muteme_devices = MuteMe.all_lights()
-if muteme_devices:
-    mute = muteme_devices[0]
-    mute.on((0, 255, 255))  # Cyan status
+try:
+    device = MuteMe.first_light()
+    if device.is_button:
+        if device.button_on:
+            device.on((255, 0, 0))  # Red when muted
+        else:
+            device.on((0, 255, 0))  # Green when unmuted
+except NoLightsFoundError:
+    pass
 ```
 
 ### Other Vendors
 
 **EPOS Busylight** - Professional conferencing light
 ```python
-from busylight_core import EPOSLights
-epos_lights = EPOSLights.all_lights()
+from busylight_core import EPOSLights, NoLightsFoundError
+
+try:
+    light = EPOSLights.first_light()
+    light.on((0, 255, 0))
+except NoLightsFoundError:
+    pass
 ```
 
 **Plantronics Status Indicator** - Call center indicator
 ```python
-from busylight_core import PlantronicsLights
-plantronics_lights = PlantronicsLights.all_lights()
+from busylight_core import PlantronicsLights, NoLightsFoundError
+
+try:
+    light = PlantronicsLights.first_light()
+    light.on((255, 0, 0))
+except NoLightsFoundError:
+    pass
 ```
 
 **CompuLab fit-statUSB** - Industrial status indicator
 ```python
-from busylight_core import CompuLabLights
-compulab_lights = CompuLabLights.all_lights()
-```
+from busylight_core import CompuLabLights, NoLightsFoundError
 
-## Common Usage Patterns
-
-### Device Detection and Selection
-
-**Vendor-Specific Selection (Recommended):**
-```python
-from busylight_core import EmbravaLights, LuxaforLights, AgileInnovativeLights
-
-# Get devices by vendor (most efficient)
-embrava_devices = EmbravaLights.all_lights()     # All Embrava devices
-luxafor_devices = LuxaforLights.all_lights()     # All Luxafor devices
-blinkstick_devices = AgileInnovativeLights.all_lights()  # All BlinkStick variants
-
-# Get first device from specific vendor
-if embrava_devices:
-    primary_light = embrava_devices[0]
-    primary_light.on((255, 0, 0), sound=True)  # Use Embrava-specific features
-```
-
-**Unified Selection (When vendor doesn't matter):**
-```python
-from busylight_core import Light
-
-# Get all devices with audio support
-audio_devices = []
-for light in Light.all_lights():
-    if hasattr(light, 'on') and 'sound' in light.on.__annotations__:
-        audio_devices.append(light)
-
-# Get multi-LED devices
-multi_led_devices = []
-for light in Light.all_lights():
-    if hasattr(light, 'on') and 'led' in light.on.__annotations__:
-        multi_led_devices.append(light)
-```
-
-### Capability Testing
-```python
-# Check device capabilities at runtime
-def get_device_features(light):
-    features = {
-        'basic_color': True,  # All devices support this
-        'flash': hasattr(light, 'flash'),
-        'multi_led': 'led' in getattr(light.on, '__annotations__', {}),
-        'audio': 'sound' in getattr(light.on, '__annotations__', {}),
-        'button': light.is_button,
-        'fade': hasattr(light, 'fade'),
-    }
-    return features
-
-# Use features to adapt behavior
-for light in Light.all_lights():
-    features = get_device_features(light)
-    
-    if features['audio']:
-        light.on((255, 0, 0), sound=True)
-    elif features['flash']:
-        light.flash((255, 0, 0))
-    else:
-        light.on((255, 0, 0))
+try:
+    light = CompuLabLights.first_light()
+    light.on((255, 165, 0))
+except NoLightsFoundError:
+    pass
 ```
 
 ## Hardware Notes
 
-### USB Device IDs
-Each device type uses specific USB vendor/product ID combinations. Some vendors use the same USB ID for multiple products (differentiated by firmware or physical design).
-
 ### Color Ordering
-Devices use different internal color formats, but the library automatically handles all conversions:
-- Most devices: RGB (0-255)
+
+Devices use different internal color byte orders, but the library handles all conversions automatically. You always pass standard RGB tuples:
+
 - BlinkStick devices: GRB ordering internally
-- Blynclight devices: RBG ordering internally  
+- Blynclight devices: RBG ordering internally
 - Kuando Busylight devices: RGB with 0-100 scaling internally
 
 ### Power Requirements
+
 All supported devices are USB bus-powered and require no external power supply.
 
 ### Platform Compatibility
+
 All devices work on Windows, macOS, and Linux. Linux users need udev rules for non-root access (see [Installation Guide](../getting-started/installation.md#linux-setup-udev-rules)).
 
 ## Next Steps
 
-- Check the [Examples](examples.md) for device-specific usage patterns
+- Check the [Examples](examples.md) for more usage patterns
 - Review the [API Reference](../reference/index.md) for complete method documentation
 - See [Installation Guide](../getting-started/installation.md) for setup instructions

--- a/docs/user-guide/examples.md
+++ b/docs/user-guide/examples.md
@@ -19,9 +19,8 @@ try:
     print(f"Using: {light.vendor()} {light.name}")
 except NoLightsFoundError:
     print("No lights found")
-    light = None
 
-# Find lights by vendor  
+# Find lights by vendor
 embrava_lights = [l for l in lights if l.vendor() == "Embrava"]
 ```
 
@@ -32,155 +31,229 @@ from busylight_core import Light, NoLightsFoundError
 
 try:
     light = Light.first_light()
-    
+
     # Turn on with different colors
     light.on((255, 0, 0))    # Red
     light.on((0, 255, 0))    # Green
     light.on((0, 0, 255))    # Blue
     light.on((255, 255, 0))  # Yellow
-    
+
     # Turn off
     light.off()
-    
-    # Check if light is on
-    if light.is_on:
-        print("Light is currently on")
-        
+
+    # Check state
+    print(f"Color: {light.color}")
+    print(f"Is lit: {light.is_lit}")
+
 except NoLightsFoundError:
     print("No lights found")
 ```
 
-## Advanced Light Control
+## Vendor-Specific Examples
 
-### Flash Patterns and Effects
-
-```python
-# Flash patterns
-light.flash((255, 0, 0), count=3)           # Flash red 3 times
-light.flash((0, 255, 0), duration=0.5)      # Custom flash duration
-light.flash((255, 255, 0), count=5, delay=0.2)  # Custom count and delay
-
-# Fade effects (for supported devices like Blink(1))
-if hasattr(light, 'fade'):
-    light.fade((255, 0, 0), duration=2.0)   # Fade to red over 2 seconds
-```
-
-### Multi-LED Device Control
+### Embrava Blynclight - Flash and Brightness
 
 ```python
-from busylight_core import BlinkStick
+from busylight_core import EmbravaLights, NoLightsFoundError
+from busylight_core.vendors.embrava.implementation import FlashSpeed
 
-# Find BlinkStick devices (support multiple LEDs)
-blinksticks = [l for l in Light.available() if isinstance(l, BlinkStick)]
+try:
+    light = EmbravaLights.first_light()
 
-if blinksticks:
-    stick = blinksticks[0]
-    
-    # Control individual LEDs
-    stick.set_led(0, (255, 0, 0))    # First LED red
-    stick.set_led(1, (0, 255, 0))    # Second LED green
-    stick.set_led(2, (0, 0, 255))    # Third LED blue
-    
-    # Set all LEDs to same color
-    stick.set_all((255, 255, 255))   # All white
+    # Solid color
+    light.on((255, 0, 0))
+
+    # Dim and restore
+    light.dim()
+    light.bright()
+
+    # Flash with default speed
+    light.flash((255, 255, 0))
+
+    # Flash with explicit speed
+    light.flash((255, 0, 0), speed=FlashSpeed.slow)
+
+    # Stop flashing
+    light.stop_flashing()
+
+    # Turn off
+    light.off()
+
+except NoLightsFoundError:
+    print("No Embrava devices found")
 ```
 
-### Audio-Enabled Devices
+### Embrava Blynclight Plus - Audio
 
 ```python
-from busylight_core import Blynclight
+from busylight_core import BlynclightPlus, NoLightsFoundError
 
-# Find Blynclight devices (support audio)
-blynclights = [l for l in Light.available() if isinstance(l, Blynclight)]
+try:
+    light = BlynclightPlus.first_light()
 
-if blynclights:
-    blight = blynclights[0]
-    
-    # Control with sound
-    blight.on((255, 0, 0), sound=True)      # Red with sound
-    blight.flash((255, 255, 0), sound=True)  # Flash yellow with sound
-    
-    # Mute/unmute functions
-    blight.mute()
-    blight.unmute()
+    # Turn on with color
+    light.on((255, 0, 0))
+
+    # Play a sound (music track 0-7, volume 0-3)
+    light.play_sound(music=0, volume=2, repeat=False)
+
+    # Mute/unmute
+    light.mute()
+    light.unmute()
+
+    # Stop sound
+    light.stop_sound()
+
+    light.off()
+
+except NoLightsFoundError:
+    print("No Blynclight Plus devices found")
 ```
 
-## Async Programming
+### Kuando Busylight - Basic Usage
 
-### Using Built-in Task Management
+```python
+from busylight_core import KuandoLights, BusylightOmega, NoLightsFoundError
+
+# Any Kuando device
+try:
+    light = KuandoLights.first_light()
+    light.on((0, 255, 0))   # Keepalive managed automatically
+    # ... light stays on ...
+    light.off()              # Keepalive cancelled automatically
+except NoLightsFoundError:
+    print("No Kuando devices found")
+
+# Specific Omega devices only
+try:
+    omega = BusylightOmega.first_light()
+    omega.on((0, 0, 255))
+    omega.off()
+except NoLightsFoundError:
+    print("No Omega devices found")
+```
+
+### Luxafor Flag - Multi-LED Control
+
+```python
+from busylight_core import Flag, NoLightsFoundError
+
+try:
+    flag = Flag.first_light()
+
+    # Control individual LEDs (Flag has 6 LEDs)
+    flag.on((255, 0, 0), led=1)    # LED 1 red
+    flag.on((0, 255, 0), led=2)    # LED 2 green
+    flag.on((0, 0, 255), led=3)    # LED 3 blue
+
+    # All LEDs same color (led=0 means all)
+    flag.on((255, 255, 255))
+
+    flag.off()
+
+except NoLightsFoundError:
+    print("No Luxafor Flag devices found")
+```
+
+### BlinkStick - Multi-LED Control
+
+```python
+from busylight_core import BlinkStickSquare, BlinkStickPro, NoLightsFoundError
+
+# BlinkStick Square has 8 LEDs
+try:
+    square = BlinkStickSquare.first_light()
+    colors = [(255,0,0), (255,127,0), (255,255,0), (0,255,0),
+              (0,0,255), (75,0,130), (148,0,211), (255,255,255)]
+    for i, color in enumerate(colors):
+        square.on(color, led=i)
+except NoLightsFoundError:
+    pass
+
+# BlinkStick Pro has 64 LEDs
+try:
+    pro = BlinkStickPro.first_light()
+    pro.on((255, 0, 0), led=0)
+    pro.on((0, 255, 0), led=1)
+except NoLightsFoundError:
+    pass
+```
+
+### MuteMe - Button Input
+
+```python
+from busylight_core import MuteMe, MuteMeLights, NoLightsFoundError
+
+try:
+    device = MuteMe.first_light()
+
+    # Check button capability and state
+    if device.is_button:
+        if device.button_on:
+            print("Button is pressed")
+            device.on((255, 0, 0))  # Red = muted
+        else:
+            print("Button is not pressed")
+            device.on((0, 255, 0))  # Green = unmuted
+
+except NoLightsFoundError:
+    print("No MuteMe devices found")
+```
+
+## Task Management
+
+### Periodic Tasks (Non-Asyncio)
+
+```python
+import time
+from busylight_core import Light, NoLightsFoundError
+
+try:
+    light = Light.first_light()
+
+    # Task function receives the light instance
+    def pulse(light):
+        if light.is_lit:
+            light.off()
+        else:
+            light.on((0, 128, 255))
+
+    # Start periodic task (uses threading.Timer automatically)
+    light.add_task("pulse", pulse, interval=0.5)
+    time.sleep(5)
+    light.cancel_task("pulse")
+    light.off()
+
+except NoLightsFoundError:
+    print("No lights found")
+```
+
+### Periodic Tasks (Asyncio)
 
 ```python
 import asyncio
 from busylight_core import Light, NoLightsFoundError
 
-try:
-    light = Light.first_light()
-    
-    # Use the built-in TaskableMixin for animations
-    async def pulse_animation():
-        """Custom pulse animation"""
-        for _ in range(10):
-            light.on((255, 0, 0))
-            await asyncio.sleep(0.5)
-            light.off()
-            await asyncio.sleep(0.5)
-    
-    # Add and manage tasks
-    task = light.add_task("pulse", pulse_animation)
-    print(f"Started task: {task}")
-    
-    # Cancel task later
-    light.cancel_task("pulse")
-    
-    # Cancel all tasks
-    light.cancel_tasks()
-    
-except NoLightsFoundError:
-    print("No lights found")
-```
+async def main():
+    try:
+        light = Light.first_light()
 
+        async def color_cycle(light):
+            colors = [(255,0,0), (0,255,0), (0,0,255)]
+            for color in colors:
+                light.on(color)
+                await asyncio.sleep(0.3)
 
-## Device-Specific Features
+        # In asyncio context, automatically uses asyncio.Task
+        light.add_task("cycle", color_cycle, interval=1.0)
+        await asyncio.sleep(10)
+        light.cancel_tasks()
+        light.off()
 
-### Button Input Handling
+    except NoLightsFoundError:
+        print("No lights found")
 
-```python
-from busylight_core import MuteMe, Luxafor
-
-# For devices with button input (MuteMe, Luxafor Mute)
-devices_with_buttons = []
-for light in Light.available():
-    if isinstance(light, (MuteMe, Luxafor)) and hasattr(light, 'button_pressed'):
-        devices_with_buttons.append(light)
-
-if devices_with_buttons:
-    device = devices_with_buttons[0]
-    
-    # Check button state
-    if device.button_pressed():
-        print("Button is currently pressed")
-        device.on((255, 0, 0))  # Red when pressed
-    else:
-        device.on((0, 255, 0))  # Green when not pressed
-```
-
-### Vendor-Specific Optimizations
-
-```python
-from busylight_core import Light, Kuando
-
-# Some devices have vendor-specific features
-for light in Light.available():
-    if isinstance(light, Kuando):
-        # Kuando devices support keepalive
-        light.keepalive()
-    
-    # Check device capabilities
-    if hasattr(light, 'dim'):
-        light.dim()  # Dim the light
-    
-    if hasattr(light, 'bright'):
-        light.bright()  # Brighten the light
+asyncio.run(main())
 ```
 
 ## Error Handling and Debugging
@@ -191,12 +264,8 @@ for light in Light.available():
 from busylight_core import Light, LightUnavailableError, NoLightsFoundError
 
 try:
-    # Try to get a light
     light = Light.first_light()
-    
-    # Try to control the light
     light.on((255, 0, 0))
-    
 except NoLightsFoundError:
     print("No busylights found. Please connect a device.")
 except LightUnavailableError as error:
@@ -208,11 +277,11 @@ except Exception as error:
 ### Debugging Device Issues
 
 ```python
-import logging
+from loguru import logger
 from busylight_core import Light, Hardware
 
 # Enable debug logging
-logging.basicConfig(level=logging.DEBUG)
+logger.enable("busylight_core")
 
 # Check hardware detection
 hardware_devices = Hardware.enumerate()
@@ -229,13 +298,13 @@ print(f"Recognized {len(lights)} as lights:")
 
 for light in lights:
     print(f"  {light.vendor()} {light.name}")
-    print(f"    Claimed by: {light.__class__.__name__}")
-```
+    print(f"    Class: {light.__class__.__name__}")
 
+logger.disable("busylight_core")
+```
 
 ## Next Steps
 
 - Learn more about the [API Reference](../reference/index.md)
 - Check out [Device Capabilities](device-capabilities.md) for device-specific features
 - Read the [Contributing Guide](../contributing.md) to add support for new devices
-- Visit the [GitHub repository](https://github.com/JnyJny/busylight_core) for the latest updates

--- a/docs/user-guide/features.md
+++ b/docs/user-guide/features.md
@@ -28,9 +28,9 @@ Get detailed information about connected devices:
 for light in Light.all_lights():
     print(f"Vendor: {light.vendor()}")
     print(f"Model: {light.name}")
-    print(f"Device ID: {light.device_id}")
-    print(f"Connection Type: {light.hardware.device_type}")
-    print(f"USB Path: {light.hardware.path}")
+    print(f"Path: {light.path}")
+    print(f"Hardware: {light.hardware.manufacturer_string}")
+    print(f"Device ID: {light.hardware.device_id}")
 ```
 
 ## Color Management
@@ -42,7 +42,7 @@ Busylight Core uses RGB color tuples with integer values from 0-255:
 ```python
 try:
     light = Light.first_light()
-    
+
     # RGB tuples (0-255) - only supported format
     light.on((255, 0, 0))      # Red
     light.on((0, 255, 0))      # Green
@@ -52,208 +52,230 @@ try:
     light.on((0, 255, 255))    # Cyan
     light.on((255, 255, 255))  # White
     light.on((128, 128, 128))  # Gray (50% brightness)
-    
+
     # Turn off
     light.off()
-    
+
+    # Check state
+    print(f"Color: {light.color}")
+    print(f"Is lit: {light.is_lit}")
+
 except NoLightsFoundError:
     print("No lights available")
 ```
 
-## Advanced Device Features
+## Vendor-Specific Features
 
-### Multi-LED Devices
+Different vendors provide different capabilities beyond basic color control. These features are only available on the specific device classes listed.
 
-Control devices with multiple LEDs individually:
+### Multi-LED Devices (BlinkStick, Luxafor Flag)
 
-```python
-from busylight_core import BlinkStick, Light
-
-# Find multi-LED devices
-multi_led_devices = []
-for light in Light.all_lights():
-    if hasattr(light, 'on') and 'led' in light.on.__annotations__:
-        multi_led_devices.append(light)
-
-if multi_led_devices:
-    device = multi_led_devices[0]
-    
-    # Control individual LEDs (if supported)
-    device.on((255, 0, 0), led=0)    # First LED red
-    device.on((0, 255, 0), led=1)    # Second LED green
-    device.on((0, 0, 255), led=2)    # Third LED blue
-```
-
-### Audio-Enabled Devices
-
-Control devices with built-in audio:
+Some devices have multiple individually addressable LEDs. Use the `led` parameter on `on()`:
 
 ```python
-from busylight_core import Blynclight, Light
+from busylight_core import Flag, BlinkStickSquare, NoLightsFoundError
 
-# Find audio-capable devices
-audio_devices = []
-for light in Light.all_lights():
-    if hasattr(light, 'on') and 'sound' in light.on.__annotations__:
-        audio_devices.append(light)
-
-if audio_devices:
-    device = audio_devices[0]
-    
-    # Control with sound (if supported)
-    device.on((255, 0, 0), sound=True)      # Red with sound
-    
-    # Mute/unmute functions (if available)
-    if hasattr(device, 'mute'):
-        device.mute()
-    if hasattr(device, 'unmute'):
-        device.unmute()
-```
-
-### Flash Patterns
-
-Use hardware flash capabilities:
-
-```python
-# Check for flash support
+# Luxafor Flag has 6 LEDs
 try:
-    light = Light.first_light()
-    
-    if hasattr(light, 'flash'):
-        light.flash((255, 0, 0))  # Flash red (device-specific timing)
-        print("Device supports hardware flash")
-    else:
-        print("Device does not support hardware flash")
-        
+    flag = Flag.first_light()
+    flag.on((255, 0, 0), led=0)    # First LED red
+    flag.on((0, 255, 0), led=1)    # Second LED green
+    flag.on((0, 0, 255), led=2)    # Third LED blue
+    flag.on((255, 255, 0))         # led=0 targets all LEDs
 except NoLightsFoundError:
-    print("No lights available")
+    pass
+
+# BlinkStick Square has 8 LEDs
+try:
+    square = BlinkStickSquare.first_light()
+    square.on((255, 0, 0), led=0)
+    square.on((0, 255, 0), led=1)
+except NoLightsFoundError:
+    pass
 ```
 
-### Button Input Devices
+The `led` parameter is accepted by all devices (it's part of the base `on()` signature), but only multi-LED devices use it meaningfully. Single-LED devices ignore it.
 
-Handle button input on interactive devices:
+### Audio (Embrava Blynclight Plus Only)
+
+Only the `BlynclightPlus` has audio playback:
 
 ```python
-from busylight_core import MuteMe
+from busylight_core import BlynclightPlus, NoLightsFoundError
 
-# Find devices with button input
-button_devices = []
-for light in Light.all_lights():
-    if hasattr(light, 'button_pressed'):
-        button_devices.append(light)
+try:
+    light = BlynclightPlus.first_light()
 
-if button_devices:
-    device = button_devices[0]
-    
-    # Check button state
-    if device.button_pressed():
-        print("Button is currently pressed")
-        device.on((255, 0, 0))  # Red when pressed
-    else:
-        device.on((0, 255, 0))  # Green when not pressed
+    # Play a sound (music: 0-7, volume: 0-3)
+    light.play_sound(music=0, volume=1, repeat=False)
+
+    # Stop sound
+    light.stop_sound()
+
+    # Mute/unmute
+    light.mute()
+    light.unmute()
+
+except NoLightsFoundError:
+    print("No Blynclight Plus devices found")
 ```
+
+**Note:** The `Blynclight` and `BlynclightMini` do NOT have audio support. Only the `BlynclightPlus` class exposes `play_sound()`, `stop_sound()`, `mute()`, and `unmute()`.
+
+### Flash Patterns (Embrava Only)
+
+Only Embrava devices (`Blynclight`, `BlynclightMini`, `BlynclightPlus`) support hardware flash:
+
+```python
+from busylight_core import EmbravaLights, NoLightsFoundError
+from busylight_core.vendors.embrava.implementation import FlashSpeed
+
+try:
+    light = EmbravaLights.first_light()
+
+    # Flash with default speed
+    light.flash((255, 0, 0))
+
+    # Flash with explicit speed
+    light.flash((255, 255, 0), speed=FlashSpeed.slow)
+
+    # Stop flashing
+    light.stop_flashing()
+
+except NoLightsFoundError:
+    print("No Embrava devices found")
+```
+
+### Brightness Control (Embrava Only)
+
+```python
+from busylight_core import EmbravaLights, NoLightsFoundError
+
+try:
+    light = EmbravaLights.first_light()
+    light.on((255, 0, 0))
+    light.dim()       # Reduce brightness
+    light.bright()    # Restore full brightness
+except NoLightsFoundError:
+    pass
+```
+
+### Button Input (MuteMe, Luxafor Mute)
+
+Some devices have physical buttons. Check for button support using `is_button`:
+
+```python
+from busylight_core import MuteMe, NoLightsFoundError
+
+try:
+    device = MuteMe.first_light()
+
+    if device.is_button:
+        if device.button_on:
+            print("Button is currently pressed")
+            device.on((255, 0, 0))  # Red when pressed
+        else:
+            device.on((0, 255, 0))  # Green when not pressed
+
+except NoLightsFoundError:
+    print("No MuteMe devices found")
+```
+
+**Properties:**
+- `is_button` - `True` if the device has a physical button
+- `button_on` - `True` if the button is currently pressed
+
+These are available on `MuteMe`, `MuteMeMini`, `MuteSync`, and `Mute` (Luxafor Mute).
+
+### Kuando Keepalive
+
+Kuando Busylight devices (Alpha, Omega) require periodic keepalive packets to stay active. This is handled automatically -- when you call `on()`, a keepalive task starts. When you call `off()`, it stops. You do not need to manage keepalive manually.
+
+```python
+from busylight_core import KuandoLights, NoLightsFoundError
+
+try:
+    light = KuandoLights.first_light()
+    light.on((0, 255, 0))   # Keepalive starts automatically
+    # ... light stays on ...
+    light.off()              # Keepalive stops automatically
+except NoLightsFoundError:
+    pass
+```
+
+**Note on Kuando ringtones:** The Kuando protocol supports ringtones (9 tones plus off) and volume control at the command level, but this is not currently exposed through the public `on()` API. If you need ringtone support, you would need to work with the low-level `Step.jump()` command directly (see `busylight_core.vendors.kuando.implementation.commands`).
 
 ## Task Management
 
-### Automatic Environment Detection
+Every Light instance includes task management that automatically adapts to your environment (asyncio or threading):
 
-Every Light instance includes task management that automatically adapts to your environment:
+```python
+import time
+from busylight_core import Light, NoLightsFoundError
+
+try:
+    light = Light.first_light()
+
+    # Define a task function (receives the light as argument)
+    def blink(light):
+        if light.is_lit:
+            light.off()
+        else:
+            light.on((255, 0, 0))
+
+    # Add a periodic task
+    light.add_task("blink", blink, interval=1.0)
+
+    time.sleep(5)  # Let it blink for 5 seconds
+
+    # Cancel specific task
+    light.cancel_task("blink")
+
+    # Or cancel all tasks
+    light.cancel_tasks()
+
+except NoLightsFoundError:
+    print("No lights found")
+```
+
+### Asyncio Context
 
 ```python
 import asyncio
 from busylight_core import Light, NoLightsFoundError
 
-try:
-    light = Light.first_light()
-    
-    # Define a task function (sync or async - both work!)
-    def blink_sync():
-        """Synchronous blink function"""
-        light.on((255, 0, 0))
-        # TaskableMixin handles the periodic execution
-    
-    async def blink_async():
-        """Asynchronous blink function"""
-        light.on((0, 255, 0))
-        await asyncio.sleep(0.1)  # Can use async operations
-    
-    # Add periodic tasks - environment automatically detected
-    light.add_task("sync_blink", blink_sync, interval=1.0)     # Every 1 second
-    light.add_task("async_blink", blink_async, interval=2.0)   # Every 2 seconds
-    
-    # Works in both asyncio and non-asyncio contexts!
-    # - Asyncio context: Uses asyncio.Task
-    # - Non-asyncio context: Uses threading.Timer
-    
-    # Cancel specific task
-    light.cancel_task("sync_blink")
-    
-    # Cancel all tasks
-    light.cancel_tasks()
-    
-except NoLightsFoundError:
-    print("No lights found")
-```
-
-### Asyncio Context Example
-
-```python
-import asyncio
-from busylight_core import Light
-
 async def main():
-    light = Light.first_light()
-    
-    # In asyncio context: automatically uses asyncio.Task
-    async def fade_task():
-        for brightness in range(0, 256, 16):
-            light.on((brightness, 0, 0))
-            await asyncio.sleep(0.1)
-    
-    light.add_task("fade", fade_task, interval=3.0)  # Repeat every 3 seconds
-    await asyncio.sleep(10)  # Let it run for 10 seconds
-    light.cancel_tasks()
+    try:
+        light = Light.first_light()
 
-# Run in asyncio context
+        async def fade(light):
+            for brightness in range(0, 256, 16):
+                light.on((brightness, 0, 0))
+                await asyncio.sleep(0.1)
+
+        light.add_task("fade", fade, interval=3.0)
+        await asyncio.sleep(10)
+        light.cancel_tasks()
+
+    except NoLightsFoundError:
+        print("No lights found")
+
 asyncio.run(main())
 ```
 
-### Non-Asyncio Context Example
-
-```python
-import time
-from busylight_core import Light
-
-def main():
-    light = Light.first_light()
-    
-    # In non-asyncio context: automatically uses threading.Timer
-    def pulse_task():
-        light.on((0, 128, 255))  # Blue pulse
-        # No sleep needed - TaskableMixin handles timing
-    
-    light.add_task("pulse", pulse_task, interval=0.5)  # Pulse every 0.5 seconds
-    time.sleep(5)  # Let it run for 5 seconds
-    light.cancel_tasks()
-
-# Run in regular Python context
-main()
-```
+In asyncio contexts, tasks use `asyncio.Task`. In non-asyncio contexts, they use `threading.Timer`. The selection is automatic.
 
 ## Error Handling
 
 ### Exception Types
 
-Busylight Core provides specific exceptions:
-
 ```python
 from busylight_core import Light, LightUnavailableError, NoLightsFoundError
 
 try:
-    # Try to get a light
     light = Light.first_light()
     light.on((255, 0, 0))
-    
+
 except NoLightsFoundError:
     print("No busylights found. Please connect a device.")
 except LightUnavailableError as error:
@@ -264,14 +286,12 @@ except Exception as error:
 
 ### Hardware Debugging
 
-Debug hardware detection issues:
-
 ```python
-import logging
+from loguru import logger
 from busylight_core import Light, Hardware
 
 # Enable debug logging
-logging.basicConfig(level=logging.DEBUG)
+logger.enable("busylight_core")
 
 # Check hardware detection
 hardware_devices = Hardware.enumerate()
@@ -288,7 +308,10 @@ print(f"Recognized {len(lights)} as lights:")
 
 for light in lights:
     print(f"  {light.vendor()} {light.name}")
-    print(f"    Claimed by: {light.__class__.__name__}")
+    print(f"    Class: {light.__class__.__name__}")
+
+# Disable logging when done
+logger.disable("busylight_core")
 ```
 
 ## Next Steps


### PR DESCRIPTION
Fixes JnyJny/busylight-core#43

## Problem
Issue JnyJny/busylight#701 revealed the generated docs describe API features that don't exist. Full audit found hallucinations across all doc pages.

## Changes
Complete rewrite of all 6 doc files (`index.md`, `quickstart.md`, `configuration.md`, `features.md`, `examples.md`, `device-capabilities.md`).

### Key fixes:
- **Removed `Light.available()`** -- doesn't exist; all examples now use `Light.all_lights()`
- **Removed `sound=True` on `on()`** -- no such parameter. Audio is only on `BlynclightPlus` via `play_sound(music, volume, repeat)`
- **Removed `button_pressed()`** -- actual API is `is_button` and `button_on` properties
- **Removed hallucinated `flash()` params** -- no `count`, `duration`, `delay`; actual signature is `flash(color, speed=FlashSpeed)`
- **Removed `BlinkStick.set_led()` / `set_all()`** -- use `on(color, led=N)` like everything else
- **Removed `fade()` references** -- no public fade method exists
- **Removed `on.__annotations__` capability detection** -- wrong pattern throughout
- **Fixed logging** -- library uses loguru, not stdlib logging
- **Documented Kuando ringtone support honestly** -- protocol supports 9 ringtones + volume via `Step.jump()`, but public `on()` doesn't expose it
- **Clarified vendor-specific features** -- dim/bright (Embrava only), flash (Embrava only), audio (BlynclightPlus only), keepalive (Kuando, automatic)

### Architecture:
Every code example was verified against the actual source in `src/busylight_core/`. No method call, parameter, or import in the docs references anything that doesn't exist in the codebase.

Follow-up: JnyJny/busylight-core#44 tracks adding executable doc tests + CI gate to prevent regression.

---
*Authored by Jny*