### PR TITLE
ci: add CI workflow with unit tests, doc tests, and linting

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -15,6 +15,26 @@ test (matrix) → build → [publish, github-release] (parallel) → docs
 
 ## Workflows
 
+### ci.yml
+Continuous integration for every push to main and every PR targeting main.
+
+**Jobs:**
+1. **test** - Matrix testing (Ubuntu, macOS, Windows x Python versions):
+   - Unit tests: `pytest tests/`
+   - Doc tests: `pytest --markdown-docs docs/` (validates all Python code blocks in documentation against the real API using mock USB hardware from `docs/conftest.py`)
+2. **lint** - Ruff check and format verification
+
+**CI coverage by scenario:**
+
+| Scenario | Workflow | Unit Tests | Doc Tests | Timing |
+|----------|----------|-----------|-----------|--------|
+| Push to main | ci.yml | Yes | Yes | Post-hoc |
+| PR to main | ci.yml | Yes | Yes | Pre-merge (gate with branch protection) |
+| Tag push (release) | release.yaml | Yes | Yes | Pre-publish |
+| Push to testing | release.yaml | Yes | Yes | Post-hoc |
+
+**Note:** For PRs, CI results are advisory unless branch protection is enabled on main with required status checks. With branch protection, failing doc tests block the merge.
+
 ### release.yaml
 Main CI/CD pipeline triggered on version tags (e.g., `v1.2.3`).
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,10 +51,10 @@ jobs:
           enable-cache: true
 
       - name: Run unit tests
-        run: uv run --all-extras pytest tests/
+        run: uv run --all-extras poe test
 
       - name: Run doc tests
-        run: uv run --all-extras pytest --markdown-docs docs/ --ignore=docs/gen_ref_pages.py
+        run: uv run --all-extras poe doc-test
 
   lint:
     name: Lint

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,70 @@
+name: CI
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  get-python-versions:
+    name: Get Python test versions
+    runs-on: ubuntu-latest
+    outputs:
+      python-versions: ${{ steps.extract.outputs.versions }}
+    steps:
+      - uses: actions/checkout@v6
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+      - name: Extract Python test versions
+        id: extract
+        run: |
+          if versions=$(uv run toml get --toml-path pyproject.toml tool.busylight_core.ci.test-python-versions 2>/dev/null); then
+            echo "versions=$versions" >> $GITHUB_OUTPUT
+          else
+            echo 'versions=["3.11", "3.12", "3.13"]' >> $GITHUB_OUTPUT
+          fi
+
+  test:
+    name: Tests (${{ matrix.python-version }}, ${{ matrix.os }})
+    needs: get-python-versions
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+        python-version: ${{ fromJSON(needs.get-python-versions.outputs.python-versions) }}
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+        with:
+          python-version: ${{ matrix.python-version }}
+          enable-cache: true
+
+      - name: Run unit tests
+        run: uv run --all-extras pytest tests/
+
+      - name: Run doc tests
+        run: uv run --all-extras pytest --markdown-docs docs/ --ignore=docs/gen_ref_pages.py
+
+  lint:
+    name: Lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+        with:
+          enable-cache: true
+
+      - name: Run ruff check
+        run: uv run ruff check .
+
+      - name: Run ruff format check
+        run: uv run ruff format --check .

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,6 +40,10 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
+      - name: Install system dependencies (Linux)
+        if: runner.os == 'Linux'
+        run: sudo apt-get update && sudo apt-get install -y libusb-1.0-0-dev
+
       - name: Install uv
         uses: astral-sh/setup-uv@v7
         with:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -49,6 +49,10 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
+      - name: Install system dependencies (Linux)
+        if: runner.os == 'Linux'
+        run: sudo apt-get update && sudo apt-get install -y libusb-1.0-0-dev
+
       - name: Install uv and set Python version.
         uses: astral-sh/setup-uv@v7
         with:          

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -55,9 +55,11 @@ jobs:
           python-version: ${{ matrix.python-version }}
           enable-cache: true
 
-      - name: Run tests - ${{ matrix.python-version }} - ${{ matrix.os }}        
-        run: |
-          uv run --all-extras pytest
+      - name: Run unit tests - ${{ matrix.python-version }} - ${{ matrix.os }}        
+        run: uv run --all-extras pytest tests/
+
+      - name: Run doc tests - ${{ matrix.python-version }} - ${{ matrix.os }}
+        run: uv run --all-extras pytest --markdown-docs docs/ --ignore=docs/gen_ref_pages.py
 
   build:
     name: Build Package

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -60,10 +60,10 @@ jobs:
           enable-cache: true
 
       - name: Run unit tests - ${{ matrix.python-version }} - ${{ matrix.os }}        
-        run: uv run --all-extras pytest tests/
+        run: uv run --all-extras poe test
 
       - name: Run doc tests - ${{ matrix.python-version }} - ${{ matrix.os }}
-        run: uv run --all-extras pytest --markdown-docs docs/ --ignore=docs/gen_ref_pages.py
+        run: uv run --all-extras poe doc-test
 
   build:
     name: Build Package

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -3,7 +3,8 @@
 Python library for controlling USB status lights from various vendors using a plugin architecture.
 
 ## Commands
-- `poe test` - Run tests
+- `poe test` - Run unit tests
+- `uv run pytest --markdown-docs docs/ --ignore=docs/gen_ref_pages.py` - Run doc tests
 - `poe ruff` - Format and lint
 - `poe coverage` - Coverage report
 - `poe docs-serve` - Serve docs locally
@@ -52,3 +53,9 @@ def method(self, param: str) -> bool:
 **Patterns**: Three device types - simple (ColorableMixin), complex (Word/BitField), multi-LED (arrays). Preserve these patterns.
 
 **Quality**: Run `poe ruff` before commits.
+
+## Doc Tests
+All Python code blocks in `docs/` are tested via pytest-markdown-docs.
+Mock USB hardware lives in `docs/conftest.py`. If you change any public API,
+update the doc examples -- CI will catch mismatches. Use `continuation` marker
+for blocks that depend on prior imports, `notest` for untestable blocks.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ Python library for controlling USB status lights from various vendors using a pl
 
 ## Commands
 - `poe test` - Run unit tests
-- `uv run pytest --markdown-docs docs/ --ignore=docs/gen_ref_pages.py` - Run doc tests
+- `poe doc-test` - Run doc tests (validates Python code blocks in docs/)
 - `poe ruff` - Format and lint
 - `poe coverage` - Coverage report
 - `poe docs-serve` - Serve docs locally

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -85,8 +85,11 @@ automation. Run `poe` without arguments to see all available tasks:
 The project uses pytest with coverage reporting:
 
 ```bash
-# Run all tests
+# Run unit tests
 poe test
+
+# Run doc tests (validates all Python code blocks in docs/)
+uv run pytest --markdown-docs docs/ --ignore=docs/gen_ref_pages.py
 
 # Run tests with coverage report
 poe coverage
@@ -105,6 +108,19 @@ uv run pytest -v
 - Tests follow the naming convention `test_*.py`
 - Mock hardware devices are used for testing (no real hardware required)
 
+### Doc Tests
+
+All Python code blocks in `docs/` are automatically tested using
+[pytest-markdown-docs][pytest-markdown-docs]. This catches hallucinated
+or outdated API examples before they ship.
+
+- Every fenced Python code block is executed during CI
+- USB hardware is mocked via `docs/conftest.py` (no devices needed)
+- If a block depends on imports from the previous block, use:
+  `` ```python continuation ``
+- To exclude a block from testing: `` ```python notest ``
+- CI runs doc tests on every PR, push to main, and release
+
 ### Writing Tests
 
 When adding new features:
@@ -114,6 +130,8 @@ When adding new features:
 3. **Test both success and error cases**
 4. **Use descriptive test names** that explain the behavior being tested
 5. **Mock hardware dependencies** - tests should not require real devices
+6. **Update doc examples** - if you change an API, update the docs and
+   the doc tests will catch any mismatches
 
 Example test structure:
 ```python
@@ -267,6 +285,9 @@ poe docs-deploy
 - **Guides and examples** go in the `docs/` directory
 - **Follow 80-column line width** for markdown files
 - **Use descriptive headers** and clear examples
+- **All Python code blocks are tested** - doc examples must use real
+  method names and signatures. Mock infrastructure in `docs/conftest.py`
+  handles USB hardware. Run doc tests locally before submitting.
 
 ## Releases
 
@@ -339,3 +360,4 @@ to provide guidance on getting familiar with the codebase.
 [good-first-issue]: https://github.com/JnyJny/busylight_core/issues?q=is%3Aopen+is%3Aissue+label%3A%22good+first+issue%22
 [help-wanted]: https://github.com/JnyJny/busylight_core/issues?q=is%3Aopen+is%3Aissue+label%3A%22help+wanted%22
 [poe-the-poet]: https://poethepoet.natn.io
+[pytest-markdown-docs]: https://github.com/modal-labs/pytest-markdown-docs

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -89,7 +89,7 @@ The project uses pytest with coverage reporting:
 poe test
 
 # Run doc tests (validates all Python code blocks in docs/)
-uv run pytest --markdown-docs docs/ --ignore=docs/gen_ref_pages.py
+poe doc-test
 
 # Run tests with coverage report
 poe coverage

--- a/docs/conftest.py
+++ b/docs/conftest.py
@@ -4,13 +4,11 @@ Provides mock light infrastructure so doc code examples can run
 without physical USB hardware connected.
 """
 
-from unittest.mock import Mock, patch, PropertyMock
-from typing import ClassVar
+from unittest.mock import Mock, patch
 
 import busylight_core
 from busylight_core.hardware import ConnectionType, Hardware
 from busylight_core.light import Light
-from busylight_core.mixins import ColorableMixin
 
 
 def _make_mock_hardware(vendor_id=0x2C0D, product_id=0x0001, name="MockLight"):
@@ -129,12 +127,16 @@ def _make_light(name="MockLight", vendor="Mock", button=False):
 def _mock_first_light(name="MockLight", vendor="Mock", button=False):
     def first_light(*args, **kwargs):
         return _make_light(name=name, vendor=vendor, button=button)
+
     return first_light
 
 
 def _mock_all_lights(name="MockLight", vendor="Mock", count=1, button=False):
     def all_lights(*args, **kwargs):
-        return [_make_light(name=name, vendor=vendor, button=button) for _ in range(count)]
+        return [
+            _make_light(name=name, vendor=vendor, button=button) for _ in range(count)
+        ]
+
     return all_lights
 
 
@@ -148,13 +150,23 @@ def _setup_patches():
 
     # Core Light class
     _patches.append(patch.object(Light, "first_light", side_effect=_mock_first_light()))
-    _patches.append(patch.object(Light, "all_lights", side_effect=_mock_all_lights(count=2)))
+    _patches.append(
+        patch.object(Light, "all_lights", side_effect=_mock_all_lights(count=2))
+    )
 
     # Hardware.enumerate
-    _patches.append(patch.object(
-        Hardware, "enumerate",
-        return_value=[_make_mock_hardware(), _make_mock_hardware(vendor_id=0x27B8, product_id=0x01ED, name="blink(1)")]
-    ))
+    _patches.append(
+        patch.object(
+            Hardware,
+            "enumerate",
+            return_value=[
+                _make_mock_hardware(),
+                _make_mock_hardware(
+                    vendor_id=0x27B8, product_id=0x01ED, name="blink(1)"
+                ),
+            ],
+        )
+    )
 
     # Vendor-specific classes - patch first_light and all_lights on each
     vendor_configs = {
@@ -182,25 +194,42 @@ def _setup_patches():
         if cls is None:
             continue
         btn = cfg.get("button", False)
-        _patches.append(patch.object(
-            cls, "first_light",
-            side_effect=_mock_first_light(name=cfg["name"], vendor=cfg["vendor"], button=btn)
-        ))
-        _patches.append(patch.object(
-            cls, "all_lights",
-            side_effect=_mock_all_lights(name=cfg["name"], vendor=cfg["vendor"], button=btn)
-        ))
+        _patches.append(
+            patch.object(
+                cls,
+                "first_light",
+                side_effect=_mock_first_light(
+                    name=cfg["name"], vendor=cfg["vendor"], button=btn
+                ),
+            )
+        )
+        _patches.append(
+            patch.object(
+                cls,
+                "all_lights",
+                side_effect=_mock_all_lights(
+                    name=cfg["name"], vendor=cfg["vendor"], button=btn
+                ),
+            )
+        )
 
     # Luxafor Mute (imported from submodule)
     from busylight_core.vendors.luxafor import Mute
-    _patches.append(patch.object(
-        Mute, "first_light",
-        side_effect=_mock_first_light(name="Mute", vendor="Luxafor", button=True)
-    ))
-    _patches.append(patch.object(
-        Mute, "all_lights",
-        side_effect=_mock_all_lights(name="Mute", vendor="Luxafor", button=True)
-    ))
+
+    _patches.append(
+        patch.object(
+            Mute,
+            "first_light",
+            side_effect=_mock_first_light(name="Mute", vendor="Luxafor", button=True),
+        )
+    )
+    _patches.append(
+        patch.object(
+            Mute,
+            "all_lights",
+            side_effect=_mock_all_lights(name="Mute", vendor="Luxafor", button=True),
+        )
+    )
 
     # Start all patches
     for p in _patches:
@@ -217,12 +246,12 @@ def _teardown_patches():
 _setup_patches()
 
 import atexit
+
 atexit.register(_teardown_patches)
 
 
 def pytest_markdown_docs_globals():
     """Inject globals available to all markdown code blocks."""
-    from busylight_core.vendors.embrava.implementation import FlashSpeed
 
     return {
         # These are injected but most blocks do their own imports.

--- a/docs/conftest.py
+++ b/docs/conftest.py
@@ -4,6 +4,7 @@ Provides mock light infrastructure so doc code examples can run
 without physical USB hardware connected.
 """
 
+import atexit
 from unittest.mock import Mock, patch
 
 import busylight_core
@@ -11,7 +12,7 @@ from busylight_core.hardware import ConnectionType, Hardware
 from busylight_core.light import Light
 
 
-def _make_mock_hardware(vendor_id=0x2C0D, product_id=0x0001, name="MockLight"):
+def make_mock_hardware(vendor_id=0x2C0D, product_id=0x0001, name="MockLight"):
     """Create a mock Hardware instance."""
     hw = Mock(spec=Hardware)
     hw.device_id = (vendor_id, product_id)
@@ -39,29 +40,29 @@ class StatefulMockLight:
 
     def __init__(self, name="MockLight", vendor_name="Mock"):
         self.name = name
-        self._vendor_name = vendor_name
+        self.vendor_name = vendor_name
         self.color = (0, 0, 0)
-        self._is_lit = False
-        self.hardware = _make_mock_hardware(name=name)
+        self.lit = False
+        self.hardware = make_mock_hardware(name=name)
         self.path = "/dev/mock0"
-        self._is_button = False
-        self._button_on = False
-        self._tasks = {}
+        self.has_button = False
+        self.button_pressed = False
+        self.tasks = {}
 
     def vendor(self):
-        return self._vendor_name
+        return self.vendor_name
 
     def on(self, color, led=0):
         self.color = color
-        self._is_lit = True
+        self.lit = True
 
     def off(self):
         self.color = (0, 0, 0)
-        self._is_lit = False
+        self.lit = False
 
     @property
     def is_lit(self):
-        return self._is_lit
+        return self.lit
 
     def reset(self):
         self.off()
@@ -78,7 +79,7 @@ class StatefulMockLight:
 
     def flash(self, color, speed=None):
         self.color = color
-        self._is_lit = True
+        self.lit = True
 
     def stop_flashing(self):
         pass
@@ -99,69 +100,72 @@ class StatefulMockLight:
     # Button devices
     @property
     def is_button(self):
-        return self._is_button
+        return self.has_button
 
     @property
     def button_on(self):
-        return self._button_on
+        return self.button_pressed
 
     # Task management
     def add_task(self, name, func, interval=1.0):
-        self._tasks[name] = func
+        self.tasks[name] = func
 
     def cancel_task(self, name):
-        self._tasks.pop(name, None)
+        self.tasks.pop(name, None)
 
     def cancel_tasks(self):
-        self._tasks.clear()
+        self.tasks.clear()
 
 
-def _make_light(name="MockLight", vendor="Mock", button=False):
+def make_light(name="MockLight", vendor="Mock", button=False):
+    """Create a StatefulMockLight, optionally with button support."""
     light = StatefulMockLight(name=name, vendor_name=vendor)
     if button:
-        light._is_button = True
-        light._button_on = True
+        light.has_button = True
+        light.button_pressed = True
     return light
 
 
-def _mock_first_light(name="MockLight", vendor="Mock", button=False):
+def mock_first_light(name="MockLight", vendor="Mock", button=False):
+    """Return a factory that produces a single mock light."""
+
     def first_light(*args, **kwargs):
-        return _make_light(name=name, vendor=vendor, button=button)
+        return make_light(name=name, vendor=vendor, button=button)
 
     return first_light
 
 
-def _mock_all_lights(name="MockLight", vendor="Mock", count=1, button=False):
+def mock_all_lights(name="MockLight", vendor="Mock", count=1, button=False):
+    """Return a factory that produces a list of mock lights."""
+
     def all_lights(*args, **kwargs):
         return [
-            _make_light(name=name, vendor=vendor, button=button) for _ in range(count)
+            make_light(name=name, vendor=vendor, button=button) for _ in range(count)
         ]
 
     return all_lights
 
 
 # Build patchers that stay active for all doc tests
-_patches = []
+patches = []
 
 
-def _setup_patches():
-    """Create all patches for doc testing."""
-    global _patches
-
+def setup_patches():
+    """Create and start all patches for doc testing."""
     # Core Light class
-    _patches.append(patch.object(Light, "first_light", side_effect=_mock_first_light()))
-    _patches.append(
-        patch.object(Light, "all_lights", side_effect=_mock_all_lights(count=2))
+    patches.append(patch.object(Light, "first_light", side_effect=mock_first_light()))
+    patches.append(
+        patch.object(Light, "all_lights", side_effect=mock_all_lights(count=2))
     )
 
     # Hardware.enumerate
-    _patches.append(
+    patches.append(
         patch.object(
             Hardware,
             "enumerate",
             return_value=[
-                _make_mock_hardware(),
-                _make_mock_hardware(
+                make_mock_hardware(),
+                make_mock_hardware(
                     vendor_id=0x27B8, product_id=0x01ED, name="blink(1)"
                 ),
             ],
@@ -194,20 +198,20 @@ def _setup_patches():
         if cls is None:
             continue
         btn = cfg.get("button", False)
-        _patches.append(
+        patches.append(
             patch.object(
                 cls,
                 "first_light",
-                side_effect=_mock_first_light(
+                side_effect=mock_first_light(
                     name=cfg["name"], vendor=cfg["vendor"], button=btn
                 ),
             )
         )
-        _patches.append(
+        patches.append(
             patch.object(
                 cls,
                 "all_lights",
-                side_effect=_mock_all_lights(
+                side_effect=mock_all_lights(
                     name=cfg["name"], vendor=cfg["vendor"], button=btn
                 ),
             )
@@ -216,43 +220,40 @@ def _setup_patches():
     # Luxafor Mute (imported from submodule)
     from busylight_core.vendors.luxafor import Mute
 
-    _patches.append(
+    patches.append(
         patch.object(
             Mute,
             "first_light",
-            side_effect=_mock_first_light(name="Mute", vendor="Luxafor", button=True),
+            side_effect=mock_first_light(name="Mute", vendor="Luxafor", button=True),
         )
     )
-    _patches.append(
+    patches.append(
         patch.object(
             Mute,
             "all_lights",
-            side_effect=_mock_all_lights(name="Mute", vendor="Luxafor", button=True),
+            side_effect=mock_all_lights(name="Mute", vendor="Luxafor", button=True),
         )
     )
 
     # Start all patches
-    for p in _patches:
+    for p in patches:
         p.start()
 
 
-def _teardown_patches():
-    for p in _patches:
+def teardown_patches():
+    """Stop all patches and clear the list."""
+    for p in patches:
         p.stop()
-    _patches.clear()
+    patches.clear()
 
 
 # Start patches at import time (pytest-markdown-docs imports conftest once)
-_setup_patches()
-
-import atexit
-
-atexit.register(_teardown_patches)
+setup_patches()
+atexit.register(teardown_patches)
 
 
 def pytest_markdown_docs_globals():
     """Inject globals available to all markdown code blocks."""
-
     return {
         # These are injected but most blocks do their own imports.
         # Having them here handles any blocks that rely on prior context.

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -1,168 +1,363 @@
 # Contributing
 
-We welcome contributions to Busylight Core for Humans! This guide will help you get started.
+We welcome contributions to busylight-core! This guide will help you get
+started with development, testing, and submitting changes.
+
+We have issues labeled as [Good First Issue][good-first-issue] and
+[Help Wanted][help-wanted] which are good opportunities for new
+contributors.
 
 ## Development Setup
 
-1. Fork the repository on GitHub
-2. Clone your fork locally:
+### Prerequisites
 
-```bash
-git clone https://github.com/YOUR_USERNAME/busylight_core.git
-cd busylight_core
-```
+- Python 3.11+ 
+- [uv][astra-uv] for dependency management
+- Git for version control
+- Optional: [direnv][direnv] for automatic environment activation
 
-3. Install dependencies using `uv`:
+### Initial Setup
 
-```bash
-uv sync
-```
+1. **Clone the repository:**
+   ```bash
+   git clone https://github.com/JnyJny/busylight-core.git
+   cd busylight-core
+   ```
+
+2. **Install dependencies and create virtual environment:**
+   ```bash
+   uv sync --all-groups
+   ```
+
+3. **Optional: Enable direnv for automatic environment activation:**
+   ```bash
+   direnv allow
+   ```
+
+4. **Verify installation:**
+   ```bash
+   uv run poe test
+   ```
 
 ## Development Workflow
 
-### Code Quality
+### Available Commands
 
-We use several tools to maintain code quality:
+The project uses [Poe the Poet][poe-the-poet]  for task
+automation. Run `poe` without arguments to see all available tasks:
 
-```bash
-# Run all code quality checks
-uv run poe check
+**Code Quality:**
+- `poe test` - Run test suite with pytest
+- `poe ruff-check` - Run ruff linting checks
+- `poe ruff-format` - Format code with ruff
+- `poe ruff` - Run both check and format
+- `poe coverage` - Generate and open HTML coverage report
 
-# Or run individual tools
-uv run poe ruff      # Linting and formatting
-```
+**Development:**
+- `poe docs-serve` - Serve documentation locally for development
+- `poe docs-build` - Build documentation
+- `poe clean` - Remove build artifacts and cache files
 
-### Testing
+### Making Changes
 
-Run the test suite:
+1. **Create a feature branch:**
+   ```bash
+   git checkout -b features/your-feature-name
+   ```
 
-```bash
-uv run poe test
-```
+2. **Make your changes** following the project conventions
 
-Run tests with coverage:
+3. **Run quality checks:**
+   ```bash
+   poe ruff        # Format and lint code
+   poe test        # Run tests
+   poe coverage    # Check test coverage
+   ```
 
-```bash
-uv run poe coverage
-```
+4. **Commit your changes** using conventional commit format (see below)
 
-### Documentation
+5. **Push and create a pull request**
 
-Build and serve the documentation locally:
+## Testing
 
-```bash
-uv run mkdocs serve
-```
+### Running Tests
 
-The documentation will be available at `http://localhost:8000`.
-
-## Making Changes
-
-1. Create a new branch for your feature or bugfix:
-
-```bash
-git checkout -b feature/your-feature-name
-```
-
-2. Make your changes, ensuring you:
-   - Follow the existing code style
-   - Add tests for new functionality
-   - Update documentation as needed
-   - Keep commits focused and well-described
-
-3. Run the full test suite:
+The project uses pytest with coverage reporting:
 
 ```bash
-uv run poe qc
+# Run unit tests
+poe test
+
+# Run doc tests (validates all Python code blocks in docs/)
+uv run pytest --markdown-docs docs/ --ignore=docs/gen_ref_pages.py
+
+# Run tests with coverage report
+poe coverage
+
+# Run specific test file
+uv run pytest tests/test_specific.py
+
+# Run tests with verbose output
+uv run pytest -v
 ```
 
-4. Commit your changes:
+### Test Structure
 
+- `tests/` - Main test directory
+- `tests/vendor_examples/` - Vendor-specific test examples
+- Tests follow the naming convention `test_*.py`
+- Mock hardware devices are used for testing (no real hardware required)
+
+### Doc Tests
+
+All Python code blocks in `docs/` are automatically tested using
+[pytest-markdown-docs][pytest-markdown-docs]. This catches hallucinated
+or outdated API examples before they ship.
+
+- Every fenced Python code block is executed during CI
+- USB hardware is mocked via `docs/conftest.py` (no devices needed)
+- If a block depends on imports from the previous block, use:
+  `` ```python continuation ``
+- To exclude a block from testing: `` ```python notest ``
+- CI runs doc tests on every PR, push to main, and release
+
+### Writing Tests
+
+When adding new features:
+
+1. **Create tests first** (TDD approach encouraged)
+2. **Aim for >90% test coverage** for production code
+3. **Test both success and error cases**
+4. **Use descriptive test names** that explain the behavior being tested
+5. **Mock hardware dependencies** - tests should not require real devices
+6. **Update doc examples** - if you change an API, update the docs and
+   the doc tests will catch any mismatches
+
+Example test structure:
+```python
+def test_device_on_method_sets_color(self, mock_device) -> None:
+    """Test that on() method properly sets device color."""
+    mock_device.on((255, 0, 0))
+    
+    assert mock_device.color == (255, 0, 0)
+```
+
+## Architecture Overview
+
+### Core Components
+
+**busylight-core** provides a unified interface for controlling USB-connected
+status lights through a plugin-style architecture:
+
+1. **Light** (src/busylight_core/light.py) - Abstract base class for all devices
+2. **Hardware** (src/busylight_core/hardware.py) - Hardware detection and connection
+3. **Vendor implementations** (src/busylight_core/vendors/) - Device-specific classes
+4. **Mixins** (src/busylight_core/mixins/) - Shared functionality (ColorableMixin, TaskableMixin)
+
+### Adding Device Support
+
+To add support for a new device:
+
+1. **Create or use existing vendor package** in `src/busylight_core/vendors/`
+2. **Implement Light subclass** with required abstract methods:
+   - `__bytes__()` - Device protocol serialization
+   - `on()` - Turn on with color
+   - `color` property - Get/set current color
+3. **Define supported_device_ids** with vendor/product ID mappings
+4. **Import in vendor's __init__.py** and add to `__all__`
+5. **Import in main __init__.py** and add to main `__all__`
+6. **Add comprehensive tests** following existing patterns
+
+### Key Design Principles
+
+- **Device-specific classes** enable type safety and plugin discovery
+- **Minimal code duplication** (~5-10% is acceptable for hardware abstraction)
+- **Clear inheritance hierarchies** with vendor base classes
+- **Comprehensive test coverage** with mocked hardware
+
+## Commit Message Format
+
+This project uses conventional commits for automatic changelog generation.
+Use these prefixes in your commit messages:
+
+- **feat:** New features and capabilities
+- **fix:** Bug fixes and corrections  
+- **docs:** Documentation updates
+- **refactor:** Code restructuring without behavior changes
+- **perf:** Performance improvements
+- **test:** Test additions or modifications
+
+**Examples:**
 ```bash
-git add .
-git commit -m "Add your descriptive commit message"
+feat: add support for NewVendor SuperLight device
+fix: resolve color parsing issue in Blynclight
+docs: update contributing guidelines for new developers
+refactor: simplify vendor base class hierarchy
+perf: optimize Word.__str__ BitField introspection
+test: add comprehensive tests for multi-LED devices
 ```
 
-5. Push to your fork:
-
-```bash
-git push origin feature/your-feature-name
+**Commit format:**
 ```
+<type>: <description>
 
-6. Create a Pull Request on GitHub
+[optional body]
+
+[optional footer]
+```
 
 ## Code Style
 
-- We use `ruff` for linting and formatting
-- Follow PEP 8 guidelines
-- Use type hints for all functions and methods
-- Write docstrings for all public functions and classes
-- Keep functions focused and reasonably sized
+### Formatting and Linting
 
-## Testing Guidelines
+The project uses [ruff][astral-ruff] for code formatting and linting:
 
-- Write tests for all new functionality
-- Use descriptive test names
-- Test both positive and negative cases
-- Use fixtures for common test data
-- Mock external dependencies
+- **Line length:** 80 characters for markdown, flexible for code
+- **Docstrings:** Sphinx reStructuredText format with single-line summary
+- **Type hints:** Required for all public APIs
+- **Import sorting:** Automatic via ruff
+
+### Code Conventions
+
+- **Descriptive variable names** that explain purpose, not implementation
+- **No comments** - prefer clear code and comprehensive docstrings
+- **Exception handling:** Use descriptive variable names (`error` not `e`)
+- **Clean exceptions:** Use `contextlib.suppress` instead of `try/except/pass`
+
+### Docstring Format
+
+Use **Sphinx reStructuredText format** focusing on programmer intent rather 
+than type information (which is covered by type hints):
+
+```python
+def on(self, color: tuple[int, int, int], led: int = 0) -> None:
+    """Turn on the light with specified RGB color.
+
+    Sets the device to display the given color immediately. For devices
+    with multiple LEDs, use led parameter to target specific LEDs or 
+    0 for all LEDs.
+
+    :param color: RGB values from 0-255 for desired color intensity
+    :param led: Target LED index, 0 affects all LEDs
+    :raises LightUnavailableError: If device communication fails
+    """
+
+def get_colors(self) -> list[tuple[int, int, int]]:
+    """Get current colors of all LEDs.
+
+    Returns the current color state for each LED in device order.
+    Use this to save current state before making temporary changes.
+
+    :return: List of RGB tuples, one per LED in device order
+    """
+```
+
+**Key principles:**
+- **Single-line summary** describing the action or purpose
+- **Document programmer intent** - how and why other code should use this
+- **Expected inputs** - value ranges, expected content, usage patterns
+- **Actions taken** - what happens when called, side effects
+- **Exception conditions** - when might this fail and why
+- **Return value usage** - how should returned values be used
+- **Avoid type redundancy** - type hints handle type information
+- **Compact format** - use `:param name: description` rather than verbose sections
 
 ## Documentation
 
-- Update documentation for any API changes
-- Add examples for new features
-- Keep documentation clear and concise
-- Use proper markdown formatting
+### Building Documentation
 
-## Submitting Changes
-
-### Pull Request Process
-
-1. Ensure your PR description clearly describes the problem and solution
-2. Include the relevant issue number if applicable
-3. Make sure all tests pass and code quality checks pass
-4. Request review from maintainers
-5. Address any feedback promptly
-
-### Commit Messages
-
-Use clear, descriptive commit messages:
-
-```
-Add support for configuration files
-
-- Implement ConfigLoader class
-- Add tests for configuration loading
-- Update documentation with examples
-```
-
-## Release Process
-
-Releases are managed by maintainers using the following commands:
+The project uses MkDocs with the Material theme:
 
 ```bash
-# Patch release (bug fixes)
-uv run poe publish_patch
+# Serve locally for development
+poe docs-serve
 
-# Minor release (new features)
-uv run poe publish_minor
+# Build for production
+poe docs-build
 
-# Major release (breaking changes)
-uv run poe publish_major
+# Deploy to GitHub Pages (maintainers only)
+poe docs-deploy
 ```
+
+### Writing Documentation
+
+- **API documentation** is auto-generated from docstrings
+- **Guides and examples** go in the `docs/` directory
+- **Follow 80-column line width** for markdown files
+- **Use descriptive headers** and clear examples
+- **All Python code blocks are tested** - doc examples must use real
+  method names and signatures. Mock infrastructure in `docs/conftest.py`
+  handles USB hardware. Run doc tests locally before submitting.
+
+## Releases
+
+### Python Version Configuration
+
+The CI/CD test matrix uses Python versions configured in `pyproject.toml`:
+
+```toml
+[tool.busylight_core.ci]
+test-python-versions = ["3.11", "3.12", "3.13"]
+```
+
+**Benefits:**
+- Single source of truth for CI test versions
+- Automatic workflow updates when versions change
+- Graceful fallback if configuration missing
+
+**Note:** Changing these versions affects all CI/CD testing across the project.
+
+### For Maintainers
+
+Releases are handled through Poe tasks and GitHub Actions:
+
+1. **Create release:**
+   ```bash
+   poe publish_patch   # 0.1.0 → 0.1.1
+   poe publish_minor   # 0.1.1 → 0.2.0
+   poe publish_major   # 0.2.0 → 1.0.0
+   ```
+
+2. **Automated CI/CD pipeline:**
+   - Version bump in pyproject.toml
+   - Git commit, tag, and push
+   - GitHub Actions: `get-python-versions` → `test` → `build` → [`publish`, `github-release`] → `docs`
+   - Parallel execution: PyPI publishing and GitHub release creation run simultaneously
+   - Documentation deployment: Only triggered after successful releases
+   <!-- add a mermaid diagram here for the ci/cd pipline -->
+
+### Changelog
+
+The CHANGELOG.md is automatically updated using conventional commits:
+- **Features** from `feat:` commits
+- **Bug Fixes** from `fix:` and `bug:` commits  
+- **Documentation** from `docs:` commits
+- **Refactoring** from `refactor:` commits
+- **Performance** from `perf:` commits
 
 ## Getting Help
 
-- Create an issue on GitHub for bugs or feature requests
-- Join discussions in existing issues
-- Reach out to maintainers for guidance
+- **GitHub Discussions:** Ask questions and share ideas
+- **Issues:** Report bugs or request features
+- **Code Review:** All PRs receive thorough review and feedback
 
 ## Code of Conduct
 
-Please be respectful and constructive in all interactions. We want to maintain a welcoming environment for all contributors.
+We are committed to providing a welcoming and inclusive environment for all
+contributors. Please be respectful and constructive in all interactions.
 
-## License
+## Questions?
 
-By contributing to Busylight Core for Humans, you agree that your contributions will be licensed under the same license as the project.
+Don't hesitate to ask questions! Create an issue or discussion, and we'll
+help you get started. New contributors are always welcome, and we're happy
+to provide guidance on getting familiar with the codebase.
 
-Thank you for contributing to Busylight Core for Humans!
+<!-- End Links -->
+
+[astral-ruff]: https://docs.astral.sh/ruff
+[astral-uv]: https://docs.astral.sh/uv
+[direnv]: https://direnv.net/
+[good-first-issue]: https://github.com/JnyJny/busylight_core/issues?q=is%3Aopen+is%3Aissue+label%3A%22good+first+issue%22
+[help-wanted]: https://github.com/JnyJny/busylight_core/issues?q=is%3Aopen+is%3Aissue+label%3A%22help+wanted%22
+[poe-the-poet]: https://poethepoet.natn.io
+[pytest-markdown-docs]: https://github.com/modal-labs/pytest-markdown-docs

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -89,7 +89,7 @@ The project uses pytest with coverage reporting:
 poe test
 
 # Run doc tests (validates all Python code blocks in docs/)
-uv run pytest --markdown-docs docs/ --ignore=docs/gen_ref_pages.py
+poe doc-test
 
 # Run tests with coverage report
 poe coverage

--- a/docs/gen_ref_pages.py
+++ b/docs/gen_ref_pages.py
@@ -11,7 +11,10 @@ package_name = "busylight_core"
 
 # Define device vendors and their main classes for better organization
 VENDOR_INFO = {
-    "agile_innovative": ("Agile Innovative", "BlinkStick devices with multi-LED support"),
+    "agile_innovative": (
+        "Agile Innovative",
+        "BlinkStick devices with multi-LED support",
+    ),
     "embrava": ("Embrava", "Blynclight series with audio capabilities"),
     "kuando": ("Kuando", "Busylight Alpha and Omega devices"),
     "luxafor": ("Luxafor", "Flag, Mute, Orb, and Bluetooth devices"),
@@ -46,21 +49,26 @@ for path in sorted(src.rglob("*.py")):
     nav_dict[parts] = doc_path.as_posix()
 
     # Special handling for vendor implementation modules
-    if (len(parts) >= 4 and 
-        parts[0] == "busylight_core" and 
-        parts[1] == "vendors" and 
-        parts[3] == "implementation" and
-        len(parts) == 4):  # This is the main implementation __init__.py
-        
+    if (
+        len(parts) >= 4
+        and parts[0] == "busylight_core"
+        and parts[1] == "vendors"
+        and parts[3] == "implementation"
+        and len(parts) == 4
+    ):  # This is the main implementation __init__.py
         vendor_name = parts[2]
         if vendor_name in VENDOR_INFO:
             display_name, description = VENDOR_INFO[vendor_name]
-            
+
             with mkdocs_gen_files.open(full_doc_path, "w") as fd:
                 fd.write(f"# {display_name} Implementation\n\n")
                 fd.write(f"{description}\n\n")
-                fd.write("This module contains the low-level implementation details for ")
-                fd.write(f"{display_name} devices, including enumerations, bit fields, ")
+                fd.write(
+                    "This module contains the low-level implementation details for "
+                )
+                fd.write(
+                    f"{display_name} devices, including enumerations, bit fields, "
+                )
                 fd.write("and state management classes.\n\n")
                 fd.write("## Available Components\n\n")
                 fd.write(f"::: {'.'.join(parts)}\n")
@@ -83,11 +91,13 @@ with mkdocs_gen_files.open("reference/index.md", "w") as index_file:
     # Main Light class
     light_parts = ("busylight_core", "light")
     if light_parts in nav_dict:
-        index_file.write(f"- **[Light Class]({nav_dict[light_parts]})** - Main abstract base class for all busylight devices\n\n")
+        index_file.write(
+            f"- **[Light Class]({nav_dict[light_parts]})** - Main abstract base class for all busylight devices\n\n"
+        )
 
     index_file.write("## Vendor Lights Classes\n\n")
     index_file.write("**Direct vendor access for production use:**\n\n")
-    
+
     # Vendor Lights classes - primary interface for vendor-specific access
     vendor_lights_classes = [
         ("AgileInnovativeLights", "All BlinkStick devices", "agile_innovative"),
@@ -100,13 +110,14 @@ with mkdocs_gen_files.open("reference/index.md", "w") as index_file:
         ("PlantronicsLights", "Plantronics Status Indicator devices", "plantronics"),
         ("ThingMLights", "ThingM Blink(1) devices", "thingm"),
     ]
-    
+
     for class_name, description, vendor_module in vendor_lights_classes:
         # Link to the vendor-specific module page
         vendor_parts = ("busylight_core", "vendors", vendor_module)
         if vendor_parts in nav_dict:
-            index_file.write(f"- **[{class_name}]({nav_dict[vendor_parts]})** - {description}\n")
-    
+            index_file.write(
+                f"- **[{class_name}]({nav_dict[vendor_parts]})** - {description}\n"
+            )
 
     index_file.write("\n## Mixins\n\n")
 
@@ -133,19 +144,20 @@ with mkdocs_gen_files.open("reference/index.md", "w") as index_file:
             # Find all submodules for this vendor (limit to prevent overwhelming)
             vendor_submodules = []
             for parts, path in nav_dict.items():
-                if (len(parts) >= 4 and
-                    parts[0] == "busylight_core" and
-                    parts[1] == "vendors" and
-                    parts[2] == vendor_module and
-                    parts != vendor_parts):
-
+                if (
+                    len(parts) >= 4
+                    and parts[0] == "busylight_core"
+                    and parts[1] == "vendors"
+                    and parts[2] == vendor_module
+                    and parts != vendor_parts
+                ):
                     # Get the actual class name (last part)
                     class_name = parts[-1]
-                    
+
                     # Skip private modules (starting with _) and base classes (ending with _base)
                     if class_name.startswith("_") or class_name.endswith("_base"):
                         continue
-                    
+
                     # Convert snake_case to Title Case and clean up
                     display_name = class_name.replace("_", " ").title()
                     if display_name.startswith("Blynclight"):
@@ -175,84 +187,84 @@ with mkdocs_gen_files.open("reference/index.md", "w") as index_file:
 # Create a proper navigation structure for the left sidebar
 with mkdocs_gen_files.open("reference/SUMMARY.md", "w") as nav_file:
     nav_file.write("* [API Reference](index.md)\n")
-    
+
     # Main Light class
     light_parts = ("busylight_core", "light")
     if light_parts in nav_dict:
         nav_file.write(f"* [Light Class]({nav_dict[light_parts]})\n")
-    
-    
+
     # Hardware Vendors with submodules (no parent "Vendors" section)
     for vendor_module, (vendor_name, vendor_desc) in VENDOR_INFO.items():
         vendor_parts = ("busylight_core", "vendors", vendor_module)
         if vendor_parts in nav_dict:
             nav_file.write(f"* [{vendor_name}]({nav_dict[vendor_parts]})\n")
-            
+
             # Find device submodules for this vendor
             vendor_devices = []
             implementation_parts = None
-            
+
             for parts, path in nav_dict.items():
-                if (len(parts) >= 4 and
-                    parts[0] == "busylight_core" and
-                    parts[1] == "vendors" and
-                    parts[2] == vendor_module and
-                    parts != vendor_parts):
-                    
+                if (
+                    len(parts) >= 4
+                    and parts[0] == "busylight_core"
+                    and parts[1] == "vendors"
+                    and parts[2] == vendor_module
+                    and parts != vendor_parts
+                ):
                     # Check if this is the implementation module
                     if len(parts) == 4 and parts[3] == "implementation":
                         implementation_parts = (parts, path)
                         continue
-                    
+
                     # Get the actual class name (last part)
                     class_name = parts[-1]
-                    
+
                     # Skip private modules (starting with _) and base classes (ending with _base)
                     if class_name.startswith("_") or class_name.endswith("_base"):
                         continue
-                    
+
                     # Skip implementation submodules (they'll be handled separately)
                     if len(parts) >= 5 and parts[3] == "implementation":
                         continue
-                    
+
                     # Convert snake_case to Title Case
                     display_name = class_name.replace("_", " ").title()
                     vendor_devices.append((display_name, path))
-            
+
             # Add implementation link first if it exists
             if implementation_parts:
                 nav_file.write(f"    * [Implementation]({implementation_parts[1]})\n")
-            
+
             # Sort and add device submodules
             for display_name, path in sorted(vendor_devices):
                 nav_file.write(f"    * [{display_name}]({path})\n")
-    
+
     # Support Components
     nav_file.write("* Support\n")
-    
+
     # Mixins
     mixin_modules = [
         ("busylight_core.mixins.colorable", "Colorable Mixin"),
         ("busylight_core.mixins.taskable", "Taskable Mixin"),
     ]
-    
+
     for module, display_name in mixin_modules:
         parts = tuple(module.split("."))
         if parts in nav_dict:
             nav_file.write(f"    * [{display_name}]({nav_dict[parts]})\n")
-    
+
     # Exceptions
     exceptions_parts = ("busylight_core", "exceptions")
     if exceptions_parts in nav_dict:
         nav_file.write(f"    * [Exceptions]({nav_dict[exceptions_parts]})\n")
-    
+
     # Low-level utility modules
     utility_modules = [
         ("busylight_core.hardware", "Hardware"),
         ("busylight_core.hid", "HID"),
         ("busylight_core.word", "Word"),
     ]
-    
+
     for module, display_name in utility_modules:
         parts = tuple(module.split("."))
         if parts in nav_dict:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -204,7 +204,21 @@ lint.ignore = [
   # line-too-long (E501)
   "E501",
   # use-of-assert (S101)
-  "S101"
+  "S101",
+  # unused-lambda-argument (ARG005)
+  "ARG005",
+  # redefined-while-unused (F811)
+  "F811",
+  # local-variable-is-assigned-but-never-used (F841)
+  "F841",
+]
+"docs/conftest.py" = [
+  # Test infrastructure: relax annotation, docstring, and style rules
+  "ANN", "D", "E501", "INP001", "SLF001", "ARG001", "PLW0602",
+  "PLC0415", "E402",
+]
+"docs/gen_ref_pages.py" = [
+  "INP001", "E501", "B007",
 ]
 "**/implementation/*" = [
   # missing-docstring-in-init (D107)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -74,10 +74,13 @@ ruff.help = "[Code Quality] Run Ruff check and format on source."
 check.sequence = [ "ruff", ]
 check.help = "[Code Quality] Run all code quality tools on source."
 
-test.cmd = "pytest"
-test.help = "[Code Quality] Runs testing suites using pytest."
+test.cmd = "pytest tests/"
+test.help = "[Code Quality] Run unit tests."
 
-qc.sequence = [ "test", "check", ]
+doc-test.cmd = "pytest --markdown-docs docs/ --ignore=docs/gen_ref_pages.py"
+doc-test.help = "[Code Quality] Run doc tests (validates Python code blocks in docs/)."
+
+qc.sequence = [ "test", "doc-test", "check", ]
 qc.help = "[Code Quality] Run all code quality tasks."
 
 # Publish tasks

--- a/tests/test_implementation.py
+++ b/tests/test_implementation.py
@@ -144,7 +144,6 @@ def test_implementation_classmethod_first_light(subclass) -> None:
 @pytest.mark.parametrize("subclass", VENDOR_SUBCLASSES)
 def test_implementation_classmethod_first_light_filtered_false(subclass) -> None:
     """Test first_light() with filters raises NoLightsFoundError when no match."""
-
     result = subclass.first_light(
         reset=False,
         exclusive=False,
@@ -167,7 +166,6 @@ def test_implementation_classmethod_first_light_filtered_false(subclass) -> None
 @pytest.mark.parametrize("subclass", VENDOR_SUBCLASSES)
 def test_implementation_classmethod_at_path_dne(subclass) -> None:
     """Test that at_path() raises NoLightsFoundError for an invalid path."""
-
     with pytest.raises(NoLightsFoundError):
         result = subclass.at_path("Not A Path")
 
@@ -176,7 +174,6 @@ def test_implementation_classmethod_at_path_dne(subclass) -> None:
 @pytest.mark.parametrize("subclass", VENDOR_SUBCLASSES)
 def test_implementation_classmethod_at_path_exists(subclass) -> None:
     """Test that at_path() returns a light instance for valid path."""
-
     result = subclass.at_path("/BOGUS/PATH")
     assert isinstance(result, subclass)
     assert result.hardware.path == b"/BOGUS/PATH"


### PR DESCRIPTION
Completes #44

Adds a CI workflow (.github/workflows/ci.yml) that runs on every PR and push to main:

- Unit tests: pytest tests/ across Python 3.11-3.13 on Ubuntu, macOS, and Windows
- Doc tests: pytest --markdown-docs docs/ using the mock infrastructure from PR #47
- Lint: ruff check + ruff format --check

Python version matrix is pulled from pyproject.toml (same pattern as the release workflow).

With PR #47 merged and this workflow in place, a hallucinated method call in any doc code block will fail the build. Issue #44 acceptance criteria are fully met.

---
*Authored by Jny*