### PR TITLE
ci: add auto-merge on LGTM comment

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -1,0 +1,18 @@
+name: Auto-merge on LGTM
+
+on:
+  issue_comment:
+    types: [created]
+
+jobs:
+  auto-merge:
+    if: |
+      github.event.issue.pull_request &&
+      contains(github.event.comment.body, 'LGTM') &&
+      github.event.comment.user.login == 'JnyJny'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Enable auto-merge
+        run: gh pr merge ${{ github.event.issue.number }} --repo ${{ github.repository }} --squash --auto
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Adds a workflow that auto-merges PRs when you comment 'LGTM'.

How it works:
1. You comment 'LGTM' on a PR
2. Workflow enables auto-merge with --squash
3. GitHub waits for required status checks (Lint) to pass
4. PR merges automatically

Branch protection is now enabled on main:
- Required status check: Lint
- No review required
- Admins can bypass (you can still force-merge in emergencies)
- Branches don't need to be up-to-date (low friction for solo work)

Note: direct pushes to main are now blocked. Everything goes through PRs.
Test this by commenting LGTM on this PR.

---
*Authored by Jny*