### PR TITLE
fix: set testpaths so bare pytest runs unit tests only

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -152,6 +152,7 @@ docs-deploy.help = "[Documentation] Deploy documentation to GitHub Pages."
 test-python-versions = ["3.11", "3.12", "3.13", "3.14"]
 
 [tool.pytest.ini_options]
+testpaths = ["tests"]
 
 [tool.ruff]
 fix = true


### PR DESCRIPTION
Without `testpaths`, bare `pytest` discovers and collects tests from `docs/` alongside `tests/`, causing test pollution from markdown-docs code blocks that affect unit test behavior (specifically `test_hardware.py` `ConnectionType.UNKNOWN` test).

One-line fix: adds `testpaths = ["tests"]` to `[tool.pytest.ini_options]`.

Doc tests are still available via `poe doc-test` which explicitly targets `docs/`.

Authored by Jny