### PR TITLE
fix: cancel pre-existing tasks in Light.on() via Template Method

### DIFF
--- a/src/busylight_core/light.py
+++ b/src/busylight_core/light.py
@@ -533,7 +533,6 @@ class Light(abc.ABC, TaskableMixin):
         yield
         self.update()
 
-    @abc.abstractmethod
     def on(
         self,
         color: tuple[int, int, int],
@@ -541,13 +540,25 @@ class Light(abc.ABC, TaskableMixin):
     ) -> None:
         """Activate the light with the specified RGB color.
 
-        Sets the light to display the given color immediately. This is the
-        primary method for controlling light appearance and should be
-        implemented by all device-specific subclasses.
+        Cancels any pre-existing animation tasks before setting the color,
+        then dispatches to the vendor-specific _on() implementation.
 
-        For devices with multiple LEDs, use led parameter to target specific
-        LEDs or set to 0 to affect all LEDs simultaneously. Single-LED devices
-        should ignore the led parameter.
+        :param color: RGB intensity values from 0-255 for each color component
+        :param led: Target LED index, 0 affects all LEDs on the device
+        """
+        self.cancel_tasks()
+        self._on(color, led)
+
+    @abc.abstractmethod
+    def _on(
+        self,
+        color: tuple[int, int, int],
+        led: int = 0,
+    ) -> None:
+        """Vendor implementation of light activation.
+
+        Subclasses implement this to set the hardware to the given color.
+        Task cancellation is handled by on() before this method is called.
 
         :param color: RGB intensity values from 0-255 for each color component
         :param led: Target LED index, 0 affects all LEDs on the device
@@ -571,7 +582,6 @@ class Light(abc.ABC, TaskableMixin):
     def reset(self) -> None:
         """Turn the light off and cancel associated asynchronous tasks."""
         self.off()
-        self.cancel_tasks()
 
     @abc.abstractmethod
     def __bytes__(self) -> bytes:

--- a/src/busylight_core/vendors/agile_innovative/blinkstick_base.py
+++ b/src/busylight_core/vendors/agile_innovative/blinkstick_base.py
@@ -48,7 +48,7 @@ class BlinkStickBase(AgileInnovativeBase):
         """Return the byte representation of the BlinkStick state."""
         return bytes(self.state)
 
-    def on(self, color: tuple[int, int, int], led: int = 0) -> None:
+    def _on(self, color: tuple[int, int, int], led: int = 0) -> None:
         """Activate the light with the given red, green, blue color tuple.
 
         :param color: RGB color tuple (red, green, blue) with values 0-255

--- a/src/busylight_core/vendors/compulab/fit_statusb.py
+++ b/src/busylight_core/vendors/compulab/fit_statusb.py
@@ -23,7 +23,7 @@ class FitStatUSB(ColorableMixin, CompuLabBase):
 
         return buf.encode()
 
-    def on(self, color: tuple[int, int, int], led: int = 0) -> None:
+    def _on(self, color: tuple[int, int, int], led: int = 0) -> None:
         """Turn on the fit-statUSB with the specified color.
 
         :param color: RGB tuple (red, green, blue).

--- a/src/busylight_core/vendors/embrava/blynclight_base.py
+++ b/src/busylight_core/vendors/embrava/blynclight_base.py
@@ -37,7 +37,7 @@ class BlynclightBase(EmbravaBase):
         """Set the RGB color values."""
         self.state.red, self.state.green, self.state.blue = value
 
-    def on(self, color: tuple[int, int, int], led: int = 0) -> None:
+    def _on(self, color: tuple[int, int, int], led: int = 0) -> None:
         """Turn on the device with the specified color.
 
         :param color: RGB color tuple (red, green, blue)

--- a/src/busylight_core/vendors/embrava/blyncusb_base.py
+++ b/src/busylight_core/vendors/embrava/blyncusb_base.py
@@ -53,7 +53,7 @@ class BlyncusbBase(EmbravaBase):
         """Set the RGB color, snapped to the nearest palette color."""
         self._color = snap_color(*value)
 
-    def on(self, color: tuple[int, int, int], led: int = 0) -> None:
+    def _on(self, color: tuple[int, int, int], led: int = 0) -> None:
         """Turn on the device with the specified color.
 
         The RGB color will be mapped to the nearest available palette color.

--- a/src/busylight_core/vendors/epos/busylight.py
+++ b/src/busylight_core/vendors/epos/busylight.py
@@ -31,7 +31,7 @@ class Busylight(EPOSBase):
         """The number of individually addressable LEDs."""
         return self.state.nleds
 
-    def on(self, color: tuple[int, int, int], led: int = 0) -> None:
+    def _on(self, color: tuple[int, int, int], led: int = 0) -> None:
         """Turn on the EPOS Busylight with the specified color.
 
         :param color: RGB color tuple (red, green, blue) with values 0-255

--- a/src/busylight_core/vendors/kuando/busylight_base.py
+++ b/src/busylight_core/vendors/kuando/busylight_base.py
@@ -34,7 +34,7 @@ class BusylightBase(ColorableMixin, KuandoBase):
     def __bytes__(self) -> bytes:
         return bytes(self.state)
 
-    def on(self, color: tuple[int, int, int], led: int = 0) -> None:
+    def _on(self, color: tuple[int, int, int], led: int = 0) -> None:
         """Turn on the Busylight with the specified color.
 
         Automatically starts keepalive using the best available strategy
@@ -50,15 +50,16 @@ class BusylightBase(ColorableMixin, KuandoBase):
         self.add_task("keepalive", self.keepalive, interval=self.REFRESH_INTERVAL)
 
     def off(self, led: int = 0) -> None:
-        """Turn off the Busylight and cancel keepalive task.
+        """Turn off the Busylight and cancel keepalive.
+
+        Overrides the base off() to avoid restarting keepalive via _on().
 
         :param led: LED index (unused for Busylight devices)
         """
+        self.cancel_tasks()
         self.color = (0, 0, 0)
         with self.batch_update():
             self.state.steps[0].jump(self.color)
-
-        self.cancel_task("keepalive")
 
     def keepalive(self, *args, **kwargs) -> None:  # noqa: ANN002, ANN003
         """Send a keepalive command to the Busylight."""

--- a/src/busylight_core/vendors/luxafor/busytag.py
+++ b/src/busylight_core/vendors/luxafor/busytag.py
@@ -41,7 +41,7 @@ class BusyTag(ColorableMixin, LuxaforBase):
         """The number of individually addressable LEDs."""
         return 7
 
-    def on(self, color: tuple[int, int, int], led: int = 0) -> None:
+    def _on(self, color: tuple[int, int, int], led: int = 0) -> None:
         """Turn on the BusyTag with the specified color.
 
         :param color: RGB color tuple (red, green, blue)

--- a/src/busylight_core/vendors/luxafor/flag.py
+++ b/src/busylight_core/vendors/luxafor/flag.py
@@ -39,7 +39,7 @@ class Flag(LuxaforBase):
     def __bytes__(self) -> bytes:
         return bytes(self.state)
 
-    def on(self, color: tuple[int, int, int], led: int = 0) -> None:
+    def _on(self, color: tuple[int, int, int], led: int = 0) -> None:
         """Turn on a Luxafor device with the specified color tuple.
 
         :param color: RGB color tuple (red, green, blue)

--- a/src/busylight_core/vendors/muteme/muteme_base.py
+++ b/src/busylight_core/vendors/muteme/muteme_base.py
@@ -80,7 +80,7 @@ class MuteMeBase(Light):
         """True if the mute button is currently pressed."""
         raise NotImplementedError
 
-    def on(self, color: tuple[int, int, int], led: int = 0) -> None:
+    def _on(self, color: tuple[int, int, int], led: int = 0) -> None:
         """Turn on the device with the specified color.
 
         :param color: RGB color tuple (red, green, blue) with values 0-255

--- a/src/busylight_core/vendors/muteme/mutesync.py
+++ b/src/busylight_core/vendors/muteme/mutesync.py
@@ -54,7 +54,7 @@ class MuteSync(ColorableMixin, MuteMeBase):
         """True if the mute button is currently pressed."""
         return False
 
-    def on(self, color: tuple[int, int, int], led: int = 0) -> None:
+    def _on(self, color: tuple[int, int, int], led: int = 0) -> None:
         """Turn on the MuteSync with the specified color.
 
         :param color: RGB color tuple (red, green, blue) with values 0-255

--- a/src/busylight_core/vendors/thingm/blink1.py
+++ b/src/busylight_core/vendors/thingm/blink1.py
@@ -41,7 +41,7 @@ class Blink1(ThingMBase):
     def __bytes__(self) -> bytes:
         return bytes(self.state)
 
-    def on(self, color: tuple[int, int, int], led: int = 0) -> None:
+    def _on(self, color: tuple[int, int, int], led: int = 0) -> None:
         """Turn on the Blink(1) with the specified color.
 
         :param color: RGB color tuple (red, green, blue) with values 0-255

--- a/tests/test_light_comprehensive.py
+++ b/tests/test_light_comprehensive.py
@@ -21,7 +21,7 @@ class MockLightSubclass(ColorableMixin, Light):
     def __bytes__(self) -> bytes:
         return b"\x01\x02\x03\x04"
 
-    def on(self, color: tuple[int, int, int], led: int = 0) -> None:
+    def _on(self, color: tuple[int, int, int], led: int = 0) -> None:
         """Turn the light on with the specified color (mock)."""
 
 

--- a/tests/test_vendor_kuando_busylight_base.py
+++ b/tests/test_vendor_kuando_busylight_base.py
@@ -249,7 +249,7 @@ class TestKuandoBusylightBase:
 
         with (
             patch.object(busylight, "batch_update") as mock_batch,
-            patch.object(busylight, "cancel_task") as mock_cancel_task,
+            patch.object(busylight, "cancel_tasks") as mock_cancel_tasks,
         ):
             mock_batch.return_value.__enter__ = Mock()
             mock_batch.return_value.__exit__ = Mock()
@@ -260,7 +260,7 @@ class TestKuandoBusylightBase:
             assert busylight.state.steps[0].color == (0, 0, 0)
             assert busylight.state.steps[0].opcode == OpCode.Jump
             mock_batch.assert_called_once()
-            mock_cancel_task.assert_called_once_with("keepalive")
+            mock_cancel_tasks.assert_called_once()
 
     def test_on_method_with_led_parameter(self, busylight) -> None:
         """Test on() method with led parameter (should be ignored)."""
@@ -287,7 +287,7 @@ class TestKuandoBusylightBase:
         """Test off() method with led parameter (should be ignored)."""
         with (
             patch.object(busylight, "batch_update") as mock_batch,
-            patch.object(busylight, "cancel_task") as mock_cancel_task,
+            patch.object(busylight, "cancel_tasks") as mock_cancel_tasks,
         ):
             mock_batch.return_value.__enter__ = Mock()
             mock_batch.return_value.__exit__ = Mock()
@@ -296,7 +296,7 @@ class TestKuandoBusylightBase:
 
             assert busylight.color == (0, 0, 0)
             mock_batch.assert_called_once()
-            mock_cancel_task.assert_called_once_with("keepalive")
+            mock_cancel_tasks.assert_called_once()
 
     def test_vendor_hierarchy(self, busylight) -> None:
         """Test BusylightBase inherits from KuandoBase properly."""


### PR DESCRIPTION
Fixes #58. Ref: JnyJny/busylight#680

## Problem

When a light has an active animation task (rainbow, pulse, etc.), calling `on(color)` does not cancel the running animation. The animation continues overwriting the solid color, making `on()` appear to have no effect.

## Fix

Uses the Template Method pattern:

- **`Light.on()`** is now concrete: calls `cancel_tasks()` then dispatches to `_on()`
- **`Light._on()`** is the new `@abc.abstractmethod` that vendors implement
- All 11 vendor `on()` methods renamed to `_on()` with no internal logic changes
- Future vendors cannot forget to cancel tasks -- they never touch `on()` directly

### Kuando special case

Kuando's `off()` is overridden to call `cancel_tasks()` + set black directly, avoiding `_on((0,0,0))` which would restart the keepalive task. The old `cancel_task('keepalive')` is replaced with `cancel_tasks()`.

### Other cleanup

- Removed redundant `cancel_tasks()` from `Light.reset()` since `off()` -> `on()` already handles it

## Tests

850 passed, 22 skipped. Updated `MockLightSubclass` and Kuando off-method tests.

Authored by Jny